### PR TITLE
do not use `wxString` when interacting with nlohmann

### DIFF
--- a/src/slic3r/GUI/Project.cpp
+++ b/src/slic3r/GUI/Project.cpp
@@ -237,16 +237,16 @@ void ProjectPanel::on_navigated(wxWebViewEvent& event)
 void ProjectPanel::OnScriptMessage(wxWebViewEvent& evt)
 {
     try {
-        wxString strInput = evt.GetString();
+        std::string strInput = evt.GetString().ToStdString();
         json     j = json::parse(strInput);
 
-        wxString strCmd = j["command"];
+        std::string strCmd = j["command"];
 
         if (strCmd == "open_3mf_accessory") {
-            wxString accessory_path =  j["accessory_path"];
+            std::string accessory_path =  j["accessory_path"];
 
             if (!accessory_path.empty()) {
-                std::string decode_path = wxGetApp().url_decode(accessory_path.ToStdString());
+                std::string decode_path = wxGetApp().url_decode(accessory_path);
                 fs::path path(decode_path);
 
                 if (fs::exists(path)) {


### PR DESCRIPTION
# Description

This solves a compile issue about using an undefined template

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
