### PR TITLE
Fix illegitimate re-licensing of the underlying AGPL projects.

### DIFF
--- a/license.rtf
+++ b/license.rtf
@@ -1,540 +1,218 @@
-{\rtf1\adeflang1025\ansi\ansicpg936\uc2\adeff0\deff0\stshfdbch17\stshfloch0\stshfhich0\stshfbi31507\deflang1033\deflangfe2052\themelang1033\themelangfe2052\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}
-{\f13\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}\'cb\'ce\'cc\'e5{\*\falt \'cb\'ce\'cc\'e5};}{\f17\fbidi \fmodern\fcharset134\fprq1{\*\panose 02010609060101010101}\'ba\'da\'cc\'e5{\*\falt \'ba\'da\'cc\'e5};}
-{\f34\fbidi \froman\fcharset1\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\f38\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}@\'cb\'ce\'cc\'e5;}
-{\f39\fbidi \fmodern\fcharset134\fprq1{\*\panose 02010609060101010101}@\'ba\'da\'cc\'e5;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}
-{\fdbmajor\f31501\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}\'cb\'ce\'cc\'e5{\*\falt \'cb\'ce\'cc\'e5};}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
-{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}
-{\fdbminor\f31505\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}\'cb\'ce\'cc\'e5{\*\falt \'cb\'ce\'cc\'e5};}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}{\f40\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\f41\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\f43\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}{\f44\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}
-{\f45\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}{\f46\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}
-{\f47\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}{\f48\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}
-{\f172\fbidi \fnil\fcharset0\fprq2 SimSun Western{\*\falt \'cb\'ce\'cc\'e5};}{\f212\fbidi \fmodern\fcharset0\fprq1 SimHei Western{\*\falt \'ba\'da\'cc\'e5};}{\f422\fbidi \fnil\fcharset0\fprq2 @\'cb\'ce\'cc\'e5 Western;}
-{\f432\fbidi \fmodern\fcharset0\fprq1 @\'ba\'da\'cc\'e5 Western;}{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}{\fdbmajor\f31520\fbidi \fnil\fcharset0\fprq2 SimSun Western{\*\falt \'cb\'ce\'cc\'e5};}{\fhimajor\f31528\fbidi \froman\fcharset238\fprq2 Cambria CE;}
-{\fhimajor\f31529\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}{\fhimajor\f31531\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\fhimajor\f31532\fbidi \froman\fcharset162\fprq2 Cambria Tur;}
-{\fhimajor\f31535\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}{\fhimajor\f31536\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}{\fdbminor\f31560\fbidi \fnil\fcharset0\fprq2 SimSun Western{\*\falt \'cb\'ce\'cc\'e5};}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}
-{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
-{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;
-\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;}{\*\defchp 
-\fs21\kerning2\dbch\af17 }{\*\defpap \ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 \snext0 \sqformat \spriority0 Normal;}{
-\s1\qc \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel0\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs36\cf1\lang1033\langfe2052\loch\f13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink15 \sqformat \spriority9 heading 1;}{
-\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\f13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink16 \sqformat \spriority9 heading 3;}{\*\cs10 \additive \sunhideused \spriority1 Default Paragraph Font;}{\*
-\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv 
-\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af31507\afs22\alang1025 \ltrch\fcs0 \fs21\lang1033\langfe2052\kerning2\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 
-\snext11 \ssemihidden \sunhideused Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs44 \ltrch\fcs0 \b\fs44\kerning44 \sbasedon10 \slink1 \slocked \spriority9 \'b1\'ea\'cc\'e2 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 
-\b\fs32\kerning0 \sbasedon10 \slink3 \slocked \ssemihidden \spriority9 \'b1\'ea\'cc\'e2 3 Char;}{\*\cs17 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \fs18 \sbasedon10 \slink22 \slocked \'d2\'b3\'bd\'c5 Char;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 
-\fs18 \sbasedon10 \slink20 \slocked \sqformat \'d2\'b3\'c3\'bc Char;}{\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\f13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext19 Normal (Web);}{\s20\qc \li0\ri0\widctlpar\brdrb\brdrs\brdrw15\brsp20 
-\tqc\tx4153\tqr\tx8306\wrapdefault\aspalpha\aspnum\faauto\nosnaplinegrid\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs18\lang1033\langfe2052\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 
-\sbasedon0 \snext20 \slink18 \sunhideused header;}{\*\cs21 \additive \rtlch\fcs1 \af0\afs18 \ltrch\fcs0 \fs18\kerning0 \sbasedon10 \ssemihidden \'d2\'b3\'c3\'bc Char1;}{\s22\ql \li0\ri0\widctlpar
-\tqc\tx4153\tqr\tx8306\wrapdefault\aspalpha\aspnum\faauto\nosnaplinegrid\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs18\lang1033\langfe2052\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 
-\sbasedon0 \snext22 \slink17 \sunhideused \sqformat footer;}{\*\cs23 \additive \rtlch\fcs1 \af0\afs18 \ltrch\fcs0 \fs18\kerning0 \sbasedon10 \ssemihidden \'d2\'b3\'bd\'c5 Char1;}}{\*\rsidtbl \rsid0\rsid726032\rsid8347566}{\mmathPr\mmathFont34\mbrkBin0
-\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author \'ce\'e2\'bd\'ad\'c1\'d6}{\operator \'ce\'ba\'ec\'bf}{\creatim\yr2021\mo1\dy21\hr19\min52}{\revtim\yr2021\mo7\dy29\hr15\min24}{\version2}
-{\edmins1}{\nofpages7}{\nofwords949}{\nofchars5415}{\nofcharsws6352}{\vern49247}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1800\margr1800\margt1440\margb1440\gutter0\ltrsect 
-\deftab420\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\noxlattoyen
-\expshrtn\noultrlspc\dntblnsbdb\nospaceforul\formshade\horzdoc\dgmargin\dghspace180\dgvspace180\dghorigin1800\dgvorigin1440\dghshow1\dgvshow1
-\jexpand\ksulang2052\viewkind1\viewscale170\splytwnine\ftnlytwnine\htmautsp\nolnhtadjtbl\useltbaln\alntblind\lytcalctblwd\lyttblrtgr\lnbrkrule\nobrkwrptbl\wrppunct\rsidroot726032\nogrowautofit {\*\fchars 
-!),.:\'3b?]\'7d\'a1\'a7\'a1\'a4\'a1\'a6\'a1\'a5\'a8\'44\'a1\'ac\'a1\'af\'a1\'b1\'a1\'ad\'a1\'c3\'a1\'a2\'a1\'a3\'a1\'a8\'a1\'a9\'a1\'b5\'a1\'b7\'a1\'b9\'a1\'bb\'a1\'bf\'a1\'b3\'a1\'bd\'a3\'a1\'a3\'a2\'a3\'a7\'a3\'a9\'a3\'ac\'a3\'ae\'a3\'ba\'a3\'bb\'a3\'bf\'a3\'dd\'a3\'e0\'a3\'fc\'a3\'fd\'a1\'ab\'a1\'e9
-}{\*\lchars ([\'7b\'a1\'a4\'a1\'ae\'a1\'b0\'a1\'b4\'a1\'b6\'a1\'b8\'a1\'ba\'a1\'be\'a1\'b2\'a1\'bc\'a3\'a8\'a3\'ae\'a3\'db\'a3\'fb\'a1\'ea\'a3\'a4}\fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\ftnsep \ltrpar \pard\plain \ltrpar
-\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \chftnsep 
-\par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid8347566 \chftnsepc 
-\par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid8347566 \chftnsep 
-\par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid8347566 \chftnsepc 
-\par }}\ltrpar \sectd \ltrsect\linex0\endnhere\pgbrdropt32\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta \dbch .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta \dbch .}}{\*\pnseclvl3
-\pndec\pnstart1\pnindent720\pnhang {\pntxta \dbch .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta \dbch )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang 
-{\pntxtb \dbch (}{\pntxta \dbch )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
-{\pntxtb \dbch (}{\pntxta \dbch )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel0\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs36\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c8\'ed\'bc\'fe\'d0\'ed\'bf\'c9\'ba\'cd\'b7\'fe\'ce\'f1\'cc\'f5\'bf\'ee}{\rtlch\fcs1 
-\af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'d6\'d8\'d2\'aa\'cc\'e1\'d0\'d1\'a3\'ba\'d4\'da\'cf\'c2\'d4\'d8\'a1\'a2\'b0\'b2\'d7\'b0
-\'ba\'cd\'ca\'b9\'d3\'c3\'b4\'b4\'cf\'eb\'c8\'fd\'ce\'ac}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid726032 \loch\af13\hich\af13\dbch\f17 \'bf\'c6\'bc\'bc\'b9\'c9\'b7\'dd\'d3\'d0\'cf\'de}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\loch\af13\hich\af13\dbch\f17 \'b9\'ab\'cb\'be\'c8\'ed\'bc\'fe\'ba\'cd\'b7\'fe\'ce\'f1\'c7\'b0\'a3\'ac\'c7\'eb\'ce\'f1\'b1\'d8\'d7\'d0\'cf\'b8\'d4\'c4\'b6\'c1\'b1\'be\'d0\'ad\'d2\'e9\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'ca\'b9\'d3\'c3\'b1\'be\'ce\'c4\'bc\'fe\'c2\'e4\'bf\'ee\'b4\'a6\'d4\'d8\'c3\'f7\'b5\'c4\'b9\'ab\'cb\'be\'a3\'a8\'d2\'d4\'cf\'c2\'b3\'c6\loch\af13\hich\af13\dbch\f17 
-\'a1\'b0\loch\af13\hich\af13\dbch\f17 \'ce\'d2\'c3\'c7\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'cc\'e1\'b9\'a9}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 CrealityPrint}{\rtlch\fcs1 
-\af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c8\'ed\'bc\'fe\'b3\'cc\'d0\'f2\'a3\'a8\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'c8\'ed\'bc\'fe\loch\af13\hich\af13\dbch\f17 \'a1\'b1
-\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'bc\'b0\'cf\'e0\'b9\'d8\'b7\'fe\'ce\'f1\'a3\'a8\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'b7\'fe\'ce\'f1\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'ac
-\loch\af13\hich\af13\dbch\f17 \'d3\'eb\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'c9\'e8\'b1\'b8\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'bc\'b0\loch\af13\hich\af13\dbch\f17 \'a1\'b0
-\loch\af13\hich\af13\dbch\f17 \'c8\'ed\'bc\'fe\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'cd\'b3\'b3\'c6\'ce\'aa\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'b7\'fe\'ce\'f1\loch\af13\hich\af13\dbch\f17 
-\'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'bd\'ab\'ca\'dc\'b1\'be\'ca\'b9\'d3\'c3\'cc\'f5\'bf\'ee\'bc\'b0\'c6\'e4\'d4\'ae\'d2\'fd\'b5\'c4\'c6\'e4\'cb\'fb\'b7\'a8\'c2\'c9\'cc\'f5\'bf\'ee\'a3\'a8\'d2\'d4\'cf\'c2\'cd\'b3\'b3\'c6
-\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d0\'ad\'d2\'e9\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'b5\'c4\'d4\'bc\'ca\'f8\'a3\'ac\'b1\'be\'d0\'ad\'d2\'e9\'ca\'c7\'c4\'fa\'d3\'eb\'ce\'d2
-\'c3\'c7\'be\'cd\'b1\'be\'b7\'fe\'ce\'f1\'ca\'b9\'d3\'c3\'b4\'ef\'b3\'c9\'b5\'c4\'d3\'d0\'d4\'bc\'ca\'f8\'c1\'a6\'b7\'a8\'c2\'c9\'d0\'ad\'d2\'e9\'a1\'a3\'d4\'da\'bd\'d3\'ca\'dc\'b2\'a2\'d7\'f1\'ca\'d8\'b1\'be\'d0\'ad\'d2\'e9\'cc\'f5\'bf\'ee\'b5\'c4
-\'c7\'b0\'cc\'e1\'cf\'c2\'a3\'ac\'ce\'d2\'c3\'c7\'b7\'c7\'c5\'c5\'cb\'fb\'b5\'d8\'ca\'da\'d3\'e8\'c4\'fa\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'d3\'d0\'cf\'de\'d0\'ed\'bf\'c9\'a1\'a3\loch\af13\hich\af13\dbch\f17 \'a1\'b0
-\loch\af13\hich\af13\dbch\f17 \'c4\'fa\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'bb\'f2\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d3\'c3\'bb\'a7\loch\af13\hich\af13\dbch\f17 \'a1\'b1
-\loch\af13\hich\af13\dbch\f17 \'bf\'c9\'d2\'d4\'ca\'c7\'b8\'f6\'c8\'cb\'a3\'ac\'d2\'b2\'bf\'c9\'d2\'d4\'ca\'c7\'c4\'b3\'b8\'f6\'b5\'a5\'d2\'bb\'b7\'a8\'c2\'c9\'ca\'b5\'cc\'e5\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 1.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'bd\'d3
-\'ca\'dc\'b1\'be\'d0\'ad\'d2\'e9}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 1.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'c4\'fa\'bf\'c9\'cd\'a8\'b9\'fd\'d2\'d4\'cf\'c2\'b7\'bd\'ca\'bd\'bd\'d3\'ca\'dc\'b1\'be\'d0\'ad\'d2\'e9\'a3\'ba\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 a}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'b5\'e3\'bb\'f7\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'cd\'ac\'d2\'e2\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'bb\'f2\'c0\'e0\'cb\'c6\'b0\'b4\'c5\'a5\'c8\'b7
-\'c8\'cf\'bd\'d3\'ca\'dc\'b1\'be\'d0\'ad\'d2\'e9\'a3\'bb}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 b}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'a3\'a9\'b9\'b4\'d1\'a1\'b1\'be\'d0\'ad\'d2\'e9\'ce\'b2\'b6\'cb\'b5\'c4\'d1\'a1\'d4\'f1\'bf\'f2\'a3\'bb\'bb\'f2\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 c}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'ca\'b5\'bc\'ca\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 1.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'b1\'d8\'d0\'eb\'ca\'d7\'cf\'c8\'bd\'d3\'ca\'dc\'ba\'cd\'cd\'ac\'d2\'e2\'b1\'be\'d0\'ad\'d2\'e9\'b7\'bd\'bf\'c9\'ca\'b9\'d3\'c3
-\'b1\'be\'b7\'fe\'ce\'f1\'a1\'a3\'c8\'e7\'c4\'fa\'b2\'bb\'cd\'ac\'d2\'e2\'b1\'be\'d0\'ad\'d2\'e9\'cc\'f5\'bf\'ee\'a3\'ac\'c7\'eb\'b2\'bb\'d2\'aa\loch\af13\hich\af13\dbch\f17 \'cf\'c2\'d4\'d8\'a1\'a2\'b0\'b2\'d7\'b0\'a1\'a2\'d7\'a2\'b2\'e1\'bb\'f2\'ca\'b9
-\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'a1\'a3\'c8\'e7\'c4\'fa\'ce\'aa\'b9\'ba\'c2\'f2\'b1\'be\'b7\'fe\'ce\'f1\'d6\'a7\'b8\'b6\'c1\'cb\'b7\'d1\'d3\'c3\'a3\'ac\'c4\'fa\'bf\'c9\'c1\'aa\'cf\'b5\'c4\'fa\'b5\'c4\'b9\'a9\'bb\'f5\'c9\'cc\'d2\'d4\'bb\'f1\'b5\'c3
-\'cd\'cb\'bf\'ee\'a3\'ac\'b5\'ab\'b1\'d8\'d0\'eb\'b7\'fb\'ba\'cf\'b9\'ab\'cb\'be\'b5\'c4\'cd\'cb\'bf\'ee\'d5\'fe\'b2\'df\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 1.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'d3\'a6\'c8\'b7\'b1\'a3\'c4\'fa\'d2\'d1\'c4\'ea\'c2\'fa}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 18}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\loch\af13\hich\af13\dbch\f17 \'cb\'ea\'a1\'a2\'ca\'c7\'d2\'d4\'d7\'d4\'bc\'ba\'b5\'c4\'c0\'cd\'b6\'af\'ca\'d5\'c8\'eb\'b6\'c0\'c1\'a2\'c9\'fa\'bb\'ee\'b5\'c4}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 16}{\rtlch\fcs1 
-\af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'cb\'ea\'d2\'d4\'c9\'cf\'ce\'b4\'b3\'c9\'c4\'ea\'c8\'cb\'bb\'f2\'d2\'d1\'bb\'f1\'b5\'c3\'c1\'cb\'b8\'b8\'c4\'b8\'bb\'f2\'bc\'e0\'bb\'a4\'c8\'cb\'b5\'c4\'cd\'ac\'d2\'e2\'a3\'ac\'be\'df
-\'d3\'d0\'b4\'ef\'b3\'c9\'d3\'d0\'b7\'a8\'c2\'c9\'d4\'bc\'ca\'f8\'c1\'a6\'d0\'ad\'d2\'e9\'b5\'c4\'c4\'dc\'c1\'a6\'a1\'a3\'c8\'e7\'b9\'fb\'c4\'fa\'ce\'b4\'b4\'ef\'b5\'bd\'bf\'c9\'d2\'d4\'b4\'ef\'b3\'c9\'d3\'d0\'b7\'a8\'c2\'c9\'d4\'bc\'ca\'f8\'c1\'a6
-\'ba\'cf\'cd\'ac\'b5\'c4\'b7\'a8\'b6\'a8\'b3\'c9\'c8\'cb\'c4\'ea\'c1\'e4\'a3\'ac\'c4\'fa\'d3\'a6\'c8\'b7\'b1\'a3\'b1\'be\'d0\'ad\'d2\'e9\'ca\'c7\'d3\'c9\'c4\'fa\'b5\'c4\'b8\'b8\'c4\'b8\'bb\'f2\'bc\'e0\'bb\'a4\'c8\'cb\'b4\'fa\'b1\'ed\'c4\'fa\'c7\'a9
-\'ca\'f0\'c8\'b7\'c8\'cf\'b5\'c4\'a1\'a3\'c8\'e7\'c4\'fa\'b4\'fa\'b1\'ed\'cb\'fb\'c8\'cb\'a3\'a8\'c8\'e7\'c4\'b3\'b8\'f6\'b9\'ab\'cb\'be\'bb\'f2\'c4\'fa\'b5\'c4\'bf\'cd\'bb\'a7\'a3\'a9\'c8\'b7\'c8\'cf\'bd\'d3\'ca\'dc\'b1\'be\'d0\'ad\'d2\'e9\'a3\'ac
-\'c4\'fa\'c9\'f9\'c3\'f7\'b2\'a2\'b1\'a3\'d6\'a4\'c4\'fa\'d2\'d1\'be\'ad\'bb\'f1\'b5\'c3\'c1\'cb\'b3\'e4\'b7\'d6\'b5\'c4\'ca\'da\'c8\'a8\'b2\'a2\'d3\'d0\'d7\'ca\'b8\'f1\'d5\'e2\'d1\'f9\'d7\'f6\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
+{\rtf1\ansi\ansicpg936\deff0\nouicompat\deflang1033\deflangfe2052\deftab420{\fonttbl{\f0\fmodern\fprq1\fcharset134 \'ba\'da\'cc\'e5;}{\f1\fnil\fprq2\fcharset134 \'cb\'ce\'cc\'e5;}{\f2\fnil\fcharset0 Calibri;}}
+{\colortbl ;\red0\green0\blue0;\red0\green0\blue255;}
+{\stylesheet{ Normal;}{\s1 heading 1;}}
+{\*\generator Riched20 10.0.19041}{\info{\horzdoc}{\*\lchars ([\'7b\'a1\'a4\'a1\'ae\'a1\'b0\'a1\'b4\'a1\'b6\'a1\'b8\'a1\'ba\'a1\'be\'a1\'b2\'a1\'bc\'a3\'a8\'a3\'ae\'a3\'db\'a3\'fb\'a1\'ea\'a3\'a4}{\*\fchars !),.:\'3b?]\'7d\'a1\'a7\'a1\'a4\'a1\'a6\'a1\'a5\'a8\'44\'a1\'ac\'a1\'af\'a1\'b1\'a1\'ad\'a1\'c3\'a1\'a2\'a1\'a3\'a1\'a8\'a1\'a9\'a1\'b5\'a1\'b7\'a1\'b9\'a1\'bb\'a1\'bf\'a1\'b3\'a1\'bd\'a3\'a1\'a3\'a2\'a3\'a7\'a3\'a9\'a3\'ac\'a3\'ae\'a3\'ba\'a3\'bb\'a3\'bf\'a3\'dd\'a3\'e0\'a3\'fc\'a3\'fd\'a1\'ab\'a1\'e9}}
+{\*\mmathPr\mnaryLim0\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
+\pard\keep\widctlpar\s1\sb280\sa280\qc\cf1\b\f0\fs36\'c8\'ed\'bc\'fe\'d0\'ed\'bf\'c9\'ba\'cd\'b7\'fe\'ce\'f1\'cc\'f5\'bf\'ee\f1\par
 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 2.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'d0\'ed
-\'bf\'c9\'ba\'cd\'cf\'de\'d6\'c6}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 2.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'b1\'be\'b7\'fe\'ce\'f1\'ca\'b9\'d3\'c3\'b5\'c4\'c8\'ed\'bc\'fe\'b3\'cc\'d0\'f2\'a3\'ac\'c6\'e4\loch\af13\hich\af13\dbch\f17 \'cb\'f9\'d3\'d0\'c8\'a8\'ca\'bc\'d6\'d5\'d3\'c9\'ce\'d2\'c3\'c7\'bb\'f2\'ce\'d2\'c3\'c7\'b5\'c4\'b9\'a9\'d3\'a6\'c9\'cc\'d3\'b5
-\'d3\'d0\'a3\'ac\'c8\'ed\'bc\'fe\'b2\'a2\'b7\'c7\'cf\'fa\'ca\'db\'a3\'ac\'d6\'bb\'ca\'c7\'ca\'da\'d3\'e8\'c4\'fa\'ca\'b9\'d3\'c3\'d0\'ed\'bf\'c9\'a1\'a3\'d4\'da\'d7\'f1\'ca\'d8\'b1\'be\'d0\'ad\'d2\'e9\'cc\'f5\'bf\'ee\'b5\'c4\'c7\'b0\'cc\'e1\'cf\'c2
-\'a3\'ac\'c4\'fa\'bd\'ab\'b1\'bb\'ca\'da\'d3\'e8\'d2\'bb\'b8\'f6\'d4\'da\'b5\'a5\'cc\'a8\'c9\'e8\'b1\'b8\'c9\'cf\'ca\'b9\'d3\'c3\'c8\'ed\'bc\'fe\'b5\'c4\'d3\'d0\'cf\'de\'b5\'c4\'ba\'cd\'b7\'c7\'b6\'c0\'bc\'d2\'b5\'c4\'d0\'ed\'bf\'c9\'a1\'a3\'c4\'fa
-\'bd\'f6\'cf\'de\'d3\'da\'d4\'da\'b1\'be\'d0\'ad\'d2\'e9\'c3\'f7\'ca\'be\'d4\'ca\'d0\'ed\'b5\'c4\'b7\'b6\'ce\'a7\'c4\'da\'ca\'b9\'d3\'c3\'c8\'ed\'bc\'fe\'a1\'a3\'c4\'fa\'b2\'bb\'b5\'c3\'a3\'ba\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\hich\af13\dbch\af17\loch\f13 1}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c8\'c6\'bf\'aa\'c8\'ed\'bc\'fe\'d6\'d0\'b5\'c4\'c8\'ce\'ba\'ce\'bc\'bc\'ca\'f5\'cf\'de\'d6\'c6\'a3\'bb\'a3\'a8}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 2}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'b6\'d4\'c8\'ed\'bc\'fe\'bd\'f8\'d0\'d0\'b7\'b4\'cf\'f2\'b9\'a4\'b3\'cc\'a1\'a2\'b7\'b4\'b1\'e0
-\'d2\'eb\'bb\'f2\'b7\'b4\'bb\'e3\'b1\'e0\'a3\'bb\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'b8\'b4\'d6\'c6\'a1\'a2
-\'d7\'aa\'c8\'c3\'a1\'a2\'b3\'f6\'d7\'e2\'a1\'a2\'b3\'f6\'ca\'db\'a1\'a2\'b7\'d6\'b7\'a2\'bb\'f2\'d2\'d4\'c6\'e4\'cb\'fb\'b7\'bd\'ca\'bd\'cc\'e1\'b9\'a9\'c8\'ed\'bc\'fe\'a1\'a3\'c4\'fa\'bf\'c9\'bd\'ab\'bb\'f1\'b5\'c3\'b5\'c4\'d0\'ed\'bf\'c9\'d3\'eb
-\'c9\'e8\'b1\'b8\'d2\'bb\'b2\'a2\'d2\'bb\'b4\'ce\'d0\'d4\'d3\'c0\'be\'c3\'d7\'aa\'c8\'c3\'b8\'f8\'b5\'da\'c8\'fd\'b7\'bd\'a1\'a3\'c4\'b3\'d0\'a9\'c8\'ed\'bc\'fe\'bb\'f2\'c6\'e4\'d7\'e9\'bc\'fe\'bf\'c9\'c4\'dc\'bb\'f9\'d3\'da\'cb\'e6\'c8\'ed\'bc\'fe
-\'b8\'bd\'b4\'f8\'b5\'c4\'bf\'aa\'d4\'b4\'d0\'ed\'bf\'c9\'d6\'a4\'cc\'e1\'b9\'a9\'a1\'a3\'bd\'f6\'be\'cd\'bf\'aa\'d4\'b4\'c8\'ed\'bc\'fe\'b3\'cc\'d0\'f2\'b6\'f8\'d1\'d4\'a3\'ac\'bf\'aa\'d4\'b4\'d0\'ed\'bf\'c9\'d6\'a4\'b5\'c4\'cc\'f5\'bf\'ee\'d3\'c5
-\'cf\'c8\'ca\'ca\'d3\'c3\'b2\'a2\'c8\'a1\'b4\'fa\'b1\'be\'d0\'ad\'d2\'e9\'b5\'c4\'c4\'b3\'d0\'a9\'cc\'f5\'bf\'ee\'a1\'a3\'ce\'b4\'c3\'f7\'c8\'b7\loch\af13\hich\af13\dbch\f17 \'ca\'da\'d3\'e8\'b5\'c4\'cb\'f9\'d3\'d0\'c6\'e4\'cb\'fb\'c8\'a8\'c0\'fb\'be\'f9
-\'d3\'c9\'ce\'d2\'c3\'c7\'bb\'f2\'c6\'e4\'b9\'a9\'d3\'a6\'c9\'cc\'b1\'a3\'c1\'f4\'a1\'a3\'c4\'fa\'b2\'bb\'b5\'c3\'c9\'be\'b3\'fd\'bb\'f2\'b8\'fc\'b8\'c4\'c8\'ed\'bc\'fe\'b5\'c4\'c8\'ce\'ba\'ce\'b0\'e6\'c8\'a8\'ba\'cd\'cb\'f9\'d3\'d0\'c8\'a8\'d0\'c5
-\'cf\'a2\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 2.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'d3\'a6\'d2\'e2\'ca\'b6\'b5\'bd\'a3\'ac\'ce\'d2\'c3\'c7\'cd\'a8\'b9\'fd\'b1\'be\'b7\'fe\'ce\'f1\'d5\'b9\'ca\'be\'b8\'f8\'c4\'fa
-\'b5\'c4\'c4\'da\'c8\'dd\'a3\'ac\'b0\'fc\'c0\'a8\'b5\'ab\'bf\'c9\'c4\'dc\'b2\'bb\'cf\'de\'d3\'da\'ca\'d3\'c6\'b5\'a1\'a2\'d2\'f4\'c6\'b5\'a1\'a2\'ce\'c4\'d7\'d6\'a1\'a2\'cd\'bc\'c6\'ac\'b5\'c8\'a3\'ac\'be\'f9\'d3\'c9\'ce\'d2\'c3\'c7\'bb\'f2\'ce\'d2
-\'c3\'c7\'b5\'c4\'d0\'ed\'bf\'c9\'b7\'bd\'d3\'b5\'d3\'d0\'c8\'ab\'b2\'bf\'ba\'cd\'cb\'f9\'d3\'d0\'b5\'c4\'c8\'a8\'c0\'fb\'ba\'cd\'c8\'a8\'d2\'e6\'a1\'a3\'c4\'fa\'bd\'f6\'cf\'de\'d3\'da\'b0\'b4\'d4\'ad\'d1\'f9\'cb\'e6\'cd\'ac\'b1\'be\'b7\'fe\'ce\'f1
-\'ca\'b9\'d3\'c3\'d5\'e2\'d0\'a9\'c4\'da\'c8\'dd\'a1\'a3\'ce\'b4\'be\'ad\'ce\'d2\'c3\'c7\'ca\'c2\'cf\'c8\'ca\'e9\'c3\'e6\'d0\'ed\'bf\'c9\'a3\'ac\'c4\'fa\'b2\'bb\'b5\'c3\'d0\'de\'b8\'c4\'a1\'a2\'d7\'e2\'c1\'de\'a1\'a2\'b3\'f6\'d7\'e2\'a1\'a2\'b3\'f6
-\'ca\'db\'a1\'a2\'b7\'a2\'b2\'bc\'bb\'f2\'b7\'d6\'b7\'a2\'c9\'cf\'ca\'f6\'c4\'da\'c8\'dd\'a3\'a8\'ce\'de\'c2\'db\'ca\'c7\'c8\'ab\'b2\'bf\'bb\'b9\'ca\'c7\'b2\'bf\'b7\'d6\'a3\'a9\'a3\'ac\'d2\'b2\'b2\'bb\'b5\'c3\'b6\'d4\'c4\'da\'c8\'dd\'bd\'f8\'d0\'d0
-\'b1\'e0\'d2\'eb\'a1\'a2\'b8\'c4\'b1\'e4\'bb\'f2\'b4\'b4\'d7\'f7\'c4\'da\'c8\'dd\'b5\'c4\'c8\'ce\'ba\'ce\'c5\'c9\'c9\'fa\'d7\'f7\'c6\'b7\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 2.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'c0\'ed\'bd\'e2\'a3\'ac\'c4\'b3\'d0\'a9\'c4\'da\'c8\'dd\'d3\'c9\'b5\'da\'c8\'fd\'b7\'bd\'cc\'e1\'b9\'a9\'a3\'ac\'ce\'d2\'c3\'c7
-\'bf\'c9\'c4\'dc\'ce\'de\'b7\'a8\'cd\'ea\'c8\'ab\'bf\'d8\'d6\'c6\'d5\'b9\'ca\'be\'b5\'c4\'c4\'da\'c8\'dd\'a3\'ac\'ce\'d2\'c3\'c7\'bd\'ab\'b2\'bb\'ce\'aa\'c6\'e4\'ce\'de\'b7\'a8\'bf\'d8\'d6\'c6\'b5\'c4\'c4\'da\'c8\'dd\loch\af13\hich\af13\dbch\f17 \'b8\'ba
-\'d4\'f0\'a3\'ac\'c4\'fa\'d3\'a6\'d7\'d4\'d0\'d0\'be\'f6\'b6\'a8\'ca\'c7\'b7\'f1\'d2\'d4\'bc\'b0\'c8\'e7\'ba\'ce\'ca\'b9\'d3\'c3\'d5\'e2\'d0\'a9\'c4\'da\'c8\'dd\'a3\'ac\'b2\'a2\'b3\'d0\'b5\'a3\'cf\'e0\'b9\'d8\'b5\'c4\'b7\'e7\'cf\'d5\'a1\'a3\'ce\'d2
-\'c3\'c7\'bf\'c9\'b8\'f9\'be\'dd\'d7\'d4\'bc\'ba\'b5\'c4\'c5\'d0\'b6\'cf\'a3\'ac\'ce\'aa\'b7\'fb\'ba\'cf\'b7\'a8\'c2\'c9\'bb\'f2\'c6\'e4\'cb\'fb\'c4\'bf\'b5\'c4\'a3\'ac\'cb\'e6\'ca\'b1\'c9\'be\'b3\'fd\'a1\'a2\'b8\'fc\'bb\'bb\'bb\'f2\'d0\'de\'b8\'c4
-\'c4\'b3\'d0\'a9\'c4\'da\'c8\'dd\'a1\'a3\'c8\'e7\'c4\'fa\'d7\'a2\'d2\'e2\'b5\'bd\'d3\'d0\'c8\'ce\'ba\'ce\'c7\'d6\'c8\'a8\'bb\'f2\'ce\'a5\'b7\'a8\'b5\'c4\'c4\'da\'c8\'dd\'a3\'ac\'bf\'c9\'b0\'b4\'d5\'d5\'ce\'d2\'c3\'c7\'b0\'e6\'c8\'a8\'d5\'fe\'b2\'df
-\'c3\'e8\'ca\'f6\'cf\'ea\'cf\'b8\'c7\'e9\'bf\'f6\'b2\'a2\'cd\'a8\'d6\'aa\'ce\'d2\'c3\'c7\'a3\'ac\'ce\'d2\'c3\'c7\'bd\'ab\'d0\'ad\'b5\'f7\'c4\'da\'c8\'dd\'cc\'e1\'b9\'a9\'b7\'bd\'bd\'e2\'be\'f6\'bb\'f2\'d2\'c0\'b7\'a8\'b4\'a6\'c0\'ed\'a1\'a3}{\rtlch\fcs1 
-\af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 3.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ce\'d2
-\'c3\'c7\'cc\'e1\'b9\'a9\'b5\'c4\'b7\'fe\'ce\'f1}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 3.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'c4\'fa\'cd\'ac\'d2\'e2\'b1\'be\'b7\'fe\'ce\'f1\'bf\'c9\'c4\'dc\'d3\'c9\'ce\'d2\'c3\'c7\'bb\'f2\'ce\'d2\'c3\'c7\'ce\'af\'cd\'d0\'b5\'c4\'b7\'fe\'ce\'f1\'cc\'e1\'b9\'a9\'c9\'cc\'cc\'e1\'b9\'a9\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-
-\par \hich\af13\dbch\af17\loch\f13 3.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'cd\'ea\'c8\'ab\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'d0\'e8\'d2\'aa\'bc\'e6\'c8\'dd\'b5\'c4\'c9\'e8\'b1\'b8\'a1\'a2\'cd\'f8\'c2\'e7
-\'bd\'d3\'c8\'eb\'bc\'b0\'ca\'b9\'d3\'c3\'cc\'d8\'b6\'a8\'b5\'c4\'c8\'ed\'bc\'fe\'cf\'b5\'cd\'b3\'a3\'ac\'b6\'f8\'c7\'d2\'bf\'c9\'c4\'dc\'d0\'e8\'d2\'aa\'b6\'a8\'c6\'da\'b8\'fc\'d0\'c2\'a3\'ac\'b2\'a2\'bf\'c9\'c4\'dc\'ca\'dc\'b5\'bd\'c9\'cf\'ca\'f6
-\'c9\'e8\'b1\'b8\'a1\'a2\'cd\'f8\'c2\'e7\'bc\'b0\'c8\'ed\'bc\'fe\'d0\'d4\'c4\'dc\'b5\'c4\'d3\'b0\'cf\'ec\'a1\'a3\'c4\'fa\'d0\'e8\'d2\'aa\'ba\'cb\'b6\'d4\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'ca\'b9\'d3\'c3\'cb\'b5\'c3\'f7\'a3\'ac\'ba\'cb\'ca\'b5\'b2\'a2
-\'c8\'b7\'c8\'cf\'c4\'fa\'b5\'c4\'c9\'e8\'b1\'b8\'b7\'fb\'ba\'cf\loch\af13\hich\af13\dbch\f17 \'b1\'be\'b7\'fe\'ce\'f1\'d2\'aa\'c7\'f3\'b5\'c4\'c8\'ed\'d3\'b2\'bc\'fe\'d3\'a6\'d3\'c3\'bb\'b7\'be\'b3\'a1\'a3\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'bf\'c9
-\'c4\'dc\'bb\'e1\'b7\'a2\'c9\'fa\'cd\'f8\'c2\'e7\'b7\'d1\'d3\'c3\'a3\'ac\'b4\'cb\'c0\'e0\'b7\'d1\'d3\'c3\'d3\'c9\'c4\'fa\'d7\'d4\'d0\'d0\'b3\'d0\'b5\'a3\'a3\'ac\'b7\'d1\'c2\'ca\'ca\'d3\'c4\'fa\'b5\'c4\'cd\'f8\'c2\'e7\'b7\'fe\'ce\'f1\'c9\'cc\'b5\'c4
-\'b1\'ea\'d7\'bc\'b6\'f8\'b6\'a8\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 3.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ce\'d2\'c3\'c7\'bb\'e1\'be\'a1\'c1\'a6\'c8\'b7\'b1\'a3\'b7\'fe\'ce\'f1\'b5\'c4\'d7\'bc\'c8\'b7\'d0\'d4\'ba\'cd\'b3\'d6\'d0\'f8\'d0\'d4\'a3\'ac\'b5\'ab\'d3\'c9\'d3\'da\'d3\'c3\'bb\'a7\'b8\'f6\'cc\'e5
-\'b2\'ee\'d2\'ec\'bc\'b0\'b1\'be\'b7\'fe\'ce\'f1\'cd\'e2\'b2\'bf\'c8\'ed\'d3\'b2\'bc\'fe\'bc\'b0\'cd\'f8\'c2\'e7\'bb\'b7\'be\'b3\'b5\'c4\'b2\'ee\'d2\'ec\'a3\'ac\'b7\'fe\'ce\'f1\'b5\'c4\'d7\'bc\'c8\'b7\'d0\'d4\'a1\'a2\'b2\'bb\'bc\'e4\'b6\'cf\'d0\'d4
-\'bc\'b0\'bf\'c9\'d3\'c3\'d0\'d4\'bf\'c9\'c4\'dc\'c5\'bc\'b6\'fb\'bb\'e1\'ca\'dc\'b5\'bd\'cf\'de\'d6\'c6\'a1\'a3\'c4\'fa\'bf\'c9\'b8\'f9\'be\'dd\'ce\'d2\'c3\'c7\'cc\'e1\'b9\'a9\'b5\'c4\'b7\'fe\'ce\'f1\'cb\'b5\'c3\'f7\'a3\'a8\'c8\'e7\'d3\'d0\'a3\'a9
-\'b8\'c4\'c9\'c6\'b7\'fe\'ce\'f1\'b5\'c4\'d7\'bc\'c8\'b7\'d0\'d4\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 3.4 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'b1\'be\'b7\'fe\'ce\'f1\'bd\'f6\'d4\'da\'d6\'d0\'b9\'fa\'b4\'f3\'c2\'bd\'cb\'be\'b7\'a8\'b9\'dc\'cf\'bd\'c7\'f8\'be\'b3\'c4\'da\'cc\'e1
-\'b9\'a9\'a3\'ac\'ce\'d2\'c3\'c7\'b6\'d4\'b1\'be\'b7\'fe\'ce\'f1\'d4\'da\'be\'b3\'cd\'e2\'b5\'c4\'ca\'b9\'d3\'c3\'b2\'bb\'cc\'e1\'b9\'a9\'c8\'ce\'ba\'ce\'b1\'a3\'d6\'a4\'a1\'a2\'d6\'a7\'b3\'d6\'ba\'cd\'ce\'ac\'bb\'a4\'a3\'ac\'d2\'b2\'b2\'bb\'b3\'d0
-\'b5\'a3\'c8\'ce\'ba\'ce\'d4\'f0\'c8\'ce\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 4.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'b7\'fe
-\'ce\'f1\'b5\'c4\'b1\'e4\'b8\'fc}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 4.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'ce\'aa\'cc\'e1\'c9\'fd\'bf\'cd\'bb\'a7\'cc\'e5\'d1\'e9\'bc\'b0\'b2\'bb\'b6\'cf\'b4\'b4\'d0\'c2\'b5\'c4\'c4\'bf\'b5\'c4\'a3\'ac\'ce\'d2\'c3\'c7\'bf\'c9\'c4\'dc\'bb\'e1\'b2\'bb\'ca\'b1\'b6\'d4\'b1\'be\'b7\'fe\'ce\'f1\loch\af13\hich\af13\dbch\f17 \'bb\'f2
-\'c6\'e4\'c8\'ce\'ba\'ce\'b2\'bf\'b7\'d6\'bd\'f8\'d0\'d0\'d0\'de\'b8\'c4\'a1\'a3\'ce\'d2\'c3\'c7\'d2\'b2\'bf\'c9\'c4\'dc\'d4\'da\'b7\'a8\'c2\'c9\'bb\'f2\'c9\'cc\'d2\'b5\'bb\'b7\'be\'b3\'b7\'a2\'c9\'fa\'b1\'e4\'bb\'af\'a3\'ac\'bc\'cc\'d0\'f8\'cc\'e1
-\'b9\'a9\'b7\'fe\'ce\'f1\'b2\'bb\'be\'df\'d3\'d0\'c9\'cc\'d2\'b5\'ba\'cf\'c0\'ed\'d0\'d4\'b5\'c4\'c7\'e9\'bf\'f6\'cf\'c2\'a3\'ac\'cb\'e6\'ca\'b1\'b8\'fc\'b8\'c4\'bb\'f2\'c1\'d9\'ca\'b1\'d6\'d0\'b6\'cf\'a1\'a2\'d3\'c0\'be\'c3\'c8\'a1\'cf\'fb\'b1\'be
-\'b7\'fe\'ce\'f1\'b5\'c4\'c8\'ce\'ba\'ce\'b9\'a6\'c4\'dc\'bb\'f2\'d7\'e9\'bc\'fe\'a1\'a3\'b4\'cb\'cd\'e2\'a3\'ac\'ce\'aa\'d7\'ee\'b4\'f3\'cf\'de\'b6\'c8\'ca\'b9\'d3\'c3\'d7\'ca\'d4\'b4\'a3\'ac\'ce\'d2\'c3\'c7\'bf\'c9\'c4\'dc\'bb\'e1\'b6\'d4\'b3\'ac
-\'b9\'fd\'c1\'f9\'ca\'ae\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 60}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'cc\'ec\'ce\'b4\'b7\'a2\'c9\'fa\'c8\'ce\'ba\'ce
-\'bb\'ee\'b6\'af\'b5\'c4\'b5\'a5\'b8\'f6\'d5\'cb\'bb\'a7\'d3\'e8\'d2\'d4\'d7\'a2\'cf\'fa\'a1\'a3\'b3\'fd\'b7\'c7\'c1\'ed\'cd\'e2\'cc\'e1\'b9\'a9\'b2\'b9\'b3\'e4\'cc\'f5\'bf\'ee\'a3\'ac\'b7\'f1\'d4\'f2\'b1\'be\'d0\'ad\'d2\'e9\'cc\'f5\'bf\'ee\'ca\'ca
-\'d3\'c3\'d3\'da\'b7\'fe\'ce\'f1\'b5\'c4\'cb\'f9\'d3\'d0\'d0\'de\'b8\'c4\'bb\'f2\'b8\'fc\'d0\'c2\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 4.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c8\'b1\'ca\'a1\'c7\'e9\'bf\'f6\'cf\'c2\'a3\'ac\'b1\'be\'b7\'fe\'ce\'f1\'bd\'ab\'bb\'e1\'d7\'d4\'b6\'af\'cf\'c2\'d4\'d8\'b2\'a2\'b0\'b2\'d7\'b0\'c8\'ed\'bc\'fe\'b5\'c4\'b8\'fc\'d0\'c2\'a1\'a3\'c4\'fa
-\'bf\'c9\'cb\'e6\'ca\'b1\'b8\'fc\'b8\'c4\'c8\'ed\'bc\'fe\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'c9\'e8\'d6\'c3\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'ac\'d1\'a1\'d4\'f1\'bd\'fb\'d3\'c3
-\'d7\'d4\'b6\'af\'b8\'fc\'d0\'c2\'a3\'a8\'b2\'bb\'cd\'c6\'bc\'f6\'a3\'a9\'a1\'a3\'d4\'da\'c4\'b3\'d0\'a9\'c7\'e9\'bf\'f6\'cf\'c2\'a3\'a8\'c0\'fd\'c8\'e7\'a3\'ac\'ce\'aa\'b7\'fb\'ba\'cf\'b7\'a8\'c2\'c9\'b5\'c4\'c7\'bf\'d6\'c6\'d0\'d4\'b9\'e6\'b6\'a8
-\'bb\'f2\'ce\'aa\'b8\'c4\'c9\'c6\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'bf\'c9\'bf\'bf\'d0\'d4\'ba\'cd\'b0\'b2\'c8\'ab\'d0\'d4\'a3\'a9\'a3\'ac\'c4\'fa\'b1\'d8\'d0\'eb\'b0\'b4\'d5\'d5\'d2\'aa\'c7\'f3\'b6\'d4\'b1\'be\'b7\'fe\'ce\'f1\loch\af13\hich\af13\dbch\f17 
-\'bd\'f8\'d0\'d0\'b8\'fc\'d0\'c2\'a1\'a3\'b8\'fc\'d0\'c2\'ca\'a7\'b0\'dc\'bf\'c9\'c4\'dc\'bb\'e1\'b5\'bc\'d6\'c2\'b7\'fe\'ce\'f1\'b2\'bb\'bf\'c9\'d3\'c3\'a1\'a2\'ca\'fd\'be\'dd\'cb\'f0\'bb\'b5\'bb\'f2\'b6\'aa\'ca\'a7\'a1\'a2\'cf\'b5\'cd\'b3\'ca\'a7
-\'d0\'a7\'bb\'f2\'d3\'b2\'bc\'fe\'b9\'ca\'d5\'cf\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 4.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c8\'e7\'b9\'fb\'ce\'d2\'c3\'c7\'c8\'a1\'cf\'fb\'c8\'ab\'b2\'bf\'b7\'fe\'ce\'f1\'a3\'ac\'c4\'fa\'bf\'c9\'d4\'da\'b7\'fe\'ce\'f1\'d6\'d5\'d6\'b9\'ba\'f3\'ce\'d2\'c3\'c7\'cd\'a8\'d6\'aa\'b5\'c4\'ba\'cf
-\'c0\'ed\'c6\'da\'cf\'de\'c4\'da\'cf\'c2\'d4\'d8\'c4\'fa\'b4\'e6\'b4\'a2\'d4\'da\'b1\'be\'b7\'fe\'ce\'f1\'d6\'d0\'b5\'c4\'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\'a3\'ac\'b9\'fd\'c1\'cb\'b8\'c3\'cd\'a8\'d6\'aa\'b5\'c4\'ba\'cf\'c0\'ed\'c6\'da\'cf\'de\'ba\'f3
-\'a3\'ac\'c4\'fa\'b5\'c4\'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\'bd\'ab\'b1\'bb\'c9\'be\'b3\'fd\'a1\'a3\'c8\'e7\'c4\'fa\'ce\'aa\'bb\'f1\'b5\'c3\'b1\'be\'b7\'fe\'ce\'f1\'d6\'a7\'b8\'b6\'c1\'cb\'b7\'d1\'d3\'c3\'a3\'ac\'d4\'da\'ce\'d2\'c3\'c7\'c8\'a1\'cf\'fb
-\'b7\'fe\'ce\'f1\'ba\'f3\'c8\'fd\'ca\'ae\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 30}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'cc\'ec\'c4\'da\'a3\'ac\'c4\'fa
-\'bf\'c9\'d2\'d4\'ca\'e9\'c3\'e6\'d0\'ce\'ca\'bd\'c7\'eb\'c7\'f3\'cd\'cb\'bf\'ee\'a3\'ac\'ce\'d2\'c3\'c7\'bd\'ab\'b0\'b4\'c4\'fa\'ca\'b5\'bc\'ca\'ca\'b9\'d3\'c3\'b7\'fe\'ce\'f1\'b5\'c4\'c7\'e9\'bf\'f6\'b0\'b4\'b1\'c8\'c0\'fd\'ce\'aa\'c4\'fa\'cd\'cb
-\'bf\'ee\'a1\'a3\'d2\'d4\'c9\'cf\'ca\'c7\'c4\'fa\'bb\'f9\'d3\'da\'b1\'be\'d0\'ad\'d2\'e9\'be\'cd\'ce\'d2\'c3\'c7\'c8\'a1\'cf\'fb\'b7\'fe\'ce\'f1\'cb\'f9\'bb\'f1\'b5\'c3\'b5\'c4\'c8\'ab\'b2\'bf\'be\'c8\'bc\'c3\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 5.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c3\'dc
-\'c2\'eb\'ba\'cd\'d5\'cb\'ba\'c5\'b0\'b2\'c8\'ab}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 5.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'c4\'fa\'bf\'c9\'c4\'dc\'d0\'e8\'d2\'aa\'d7\'a2\'b2\'e1\'d5\'cb\'ba\'c5\'b7\'bd\'bf\'c9\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'a1\'a3\'c8\'e7\'b1\'be\'b7\'fe\'ce\'f1\'d4\'ca\'d0\'ed\'c4\'fa\'ca\'b9\'d3\'c3\'c4\'fa\'d2\'d1\'be\'ad\'d7\'a2\'b2\'e1
-\'b5\'c4\'c6\'e4\'cb\'fb\'d5\'cb\'ba\'c5\'a3\'ac\'c4\'fa\'cd\'a8\'b9\'fd\loch\af13\hich\af13\dbch\f17 \'b8\'c3\'d5\'cb\'ba\'c5\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'a3\'ac\'ca\'dc\'b1\'be\'d0\'ad\'d2\'e9\'cc\'f5\'bf\'ee\'b5\'c4\'d4\'bc\'ca\'f8\'a1\'a3}
-{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 5.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'d4\'da\'c4\'fa\'b5\'c4\'d5\'cb\'ba\'c5\'d7\'a2\'b2\'e1\'b9\'fd\'b3\'cc\'d6\'d0\'d2\'d4\'bc\'b0\'d4\'da\'b4\'cb\'ba\'f3\'ce\'d2\'c3\'c7
-\'d2\'aa\'c7\'f3\'ca\'b1\'a3\'ac\'c4\'fa\'cd\'ac\'d2\'e2\'b0\'b4\'ce\'d2\'c3\'c7\'b5\'c4\'d2\'aa\'c7\'f3\'cc\'e1\'b9\'a9\'cf\'e0\'b9\'d8\'d7\'a2\'b2\'e1\'d0\'c5\'cf\'a2\'a3\'ac\'c8\'e7\'b7\'a8\'c2\'c9\'d2\'aa\'c7\'f3\'ca\'b5\'c3\'fb\'d7\'a2\'b2\'e1
-\'b5\'c4\'a3\'ac\'c4\'fa\'d3\'a6\'cf\'f2\'ce\'d2\'c3\'c7\'cc\'e1\'b9\'a9\'d5\'e6\'ca\'b5\'a1\'a2\'d7\'bc\'c8\'b7\'a1\'a2\'d7\'ee\'d0\'c2\'ba\'cd\'cd\'ea\'d5\'fb\'b5\'c4\'d5\'cb\'ba\'c5\'b9\'dc\'c0\'ed\'d0\'c5\'cf\'a2\'ba\'cd\'ca\'fd\'be\'dd\'a3\'a8
-\'c8\'e7\'c4\'fa\'b5\'c4\'d0\'d5\'c3\'fb\'a1\'a2\'b5\'e7\'d7\'d3\'d3\'ca\'bc\'fe\'b5\'d8\'d6\'b7\'bc\'b0\'b5\'e7\'bb\'b0\'ba\'c5\'c2\'eb\'b5\'c8\'a3\'ac\'cd\'b3\'b3\'c6\'ce\'aa\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d7\'a2
-\'b2\'e1\'d0\'c5\'cf\'a2\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'a1\'a3\'c4\'fa\'d3\'a6\'ca\'bc\'d6\'d5\'ce\'ac\'bb\'a4\'b2\'a2\'bc\'b0\'ca\'b1\'b8\'fc\'d0\'c2\'c4\'fa\'b5\'c4\'d7\'a2\'b2\'e1\'d0\'c5\'cf\'a2\'a1\'a3
-\'c8\'e7\'b9\'fb\'c4\'fa\'b5\'c4\'d7\'a2\'b2\'e1\'d0\'c5\'cf\'a2\'d0\'e9\'bc\'d9\'a1\'a2\'b2\'bb\'d5\'fd\'c8\'b7\'a1\'a2\'b2\'bb\'cd\'ea\'d5\'fb\'bb\'f2\'d2\'d1\'be\'ad\'b9\'fd\'ca\'b1\'a3\'ac\'bf\'c9\'c4\'dc\'bb\'e1\'d3\'b0\'cf\'ec\'c4\'fa\'b6\'d4
-\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'ca\'b9\'d3\'c3\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 5.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'d3\'a6\'b6\'d4\'ca\'b9\'d3\'c3\'c4\'fa\'b5\'c4\'d5\'cb\'ba\'c5\'bd\'f8\'d0\'d0\'b5\'c4\'cb\'f9\'d3\'d0\'bb\'ee\'b6\'af\'b8\'ba
-\'cd\'ea\'c8\'ab\'b5\'c4\'d4\'f0\'c8\'ce\'a1\'a3\'c4\'fa\'cd\'ac\'d2\'e2\'a3\'ba\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 a}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'a3\'a9\'bd\'ab\'b2\'c9\'c8\'a1\'d2\'bb\'c7\'d0\'ba\'cf\'c0\'ed\'bf\'c9\'d0\'d0\'b5\'c4\'b4\'eb\'ca\'a9\'cd\'d7\'c9\'c6\'b1\'a3\'b9\'dc\'b1\'be\'c8\'cb\'b5\'c4\'d5\'cb\'ba\'c5\'bc\'b0\'c3\'dc\'c2\'eb\'a3\'a8\'b0\'fc\'c0\'a8\'b5\'ab\'b2\'bb\'cf\'de
-\'d3\'da\'a3\'ac\loch\af13\hich\af13\dbch\f17 \'ce\'aa\'d5\'cb\'ba\'c5\'c9\'e8\'d6\'c3\'b7\'fb\'ba\'cf\'b0\'b2\'c8\'ab\'b1\'ea\'d7\'bc\'b5\'c4\'c3\'dc\'c2\'eb\'a3\'ac\'ca\'b9\'d3\'c3\'cd\'ea\'b1\'cf\'ba\'f3\'bc\'b0\'ca\'b1\'cd\'cb\'b3\'f6\'d5\'cb\'ba\'c5
-\'a3\'a9\'a3\'bb\'c7\'d2\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 b}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'b1\'be\'c8\'cb\'d5\'cb\'ba\'c5\'d4\'e2\'b5\'bd
-\'ce\'b4\'bb\'f1\'ca\'da\'c8\'a8\'b5\'c4\'ca\'b9\'d3\'c3\'a3\'ac\'bb\'f2\'d5\'df\'b7\'a2\'c9\'fa\'c6\'e4\'cb\'fb\'c8\'ce\'ba\'ce\'b0\'b2\'c8\'ab\'ce\'ca\'cc\'e2\'ca\'b1\'a3\'ac\'bd\'ab\'c1\'a2\'bc\'b4\'cd\'a8\'d6\'aa\'ce\'d2\'c3\'c7\'a1\'a3\'b6\'d4
-\'d3\'da\'cb\'fb\'c8\'cb\'ce\'b4\'be\'ad\'ca\'da\'c8\'a8\'ca\'b9\'d3\'c3\'c4\'fa\'d5\'cb\'ba\'c5\'b6\'f8\'b2\'fa\'c9\'fa\'b5\'c4\'c8\'ce\'ba\'ce\'cb\'f0\'ca\'a7\'bb\'f2\'cb\'f0\'ba\'a6\'a3\'ac\'ce\'d2\'c3\'c7\'ce\'de\'b7\'a8\'d2\'b2\'b2\'bb\'b3\'d0
-\'b5\'a3\'c8\'ce\'ba\'ce\'d4\'f0\'c8\'ce\'a1\'a3\'c8\'e7\'ce\'d2\'c3\'c7\'b7\'a2\'cf\'d6\'c8\'ce\'ba\'ce\'d5\'cb\'bb\'a7\'b4\'e6\'d4\'da\'b0\'b2\'c8\'ab\'ce\'ca\'cc\'e2\'a3\'ac\'d3\'d0\'c8\'a8\'b8\'f9\'be\'dd\'d7\'d4\'bc\'ba\'b5\'c4\'c5\'d0\'b6\'cf
-\'b4\'a6\'c0\'ed\'a3\'ac\'b0\'fc\'c0\'a8\'b5\'ab\'b2\'bb\'cf\'de\'d3\'da\'cf\'de\'d6\'c6\'bb\'f2\'bd\'fb\'d6\'b9\'b8\'c3\'d5\'cb\'ba\'c5\'ca\'b9\'d3\'c3\'a3\'ac\'d6\'b1\'d6\'c1\'d7\'a2\'cf\'fa\'b8\'c3\'d5\'cb\'ba\'c5\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 6.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa
-\'d0\'e8\'d2\'aa\'d7\'f1\'ca\'d8\'b5\'c4\'b9\'e6\'b7\'b6}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 6.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'c4\'fa\'b2\'bb\'b5\'c3\'ce\'aa\'c8\'ce\'ba\'ce\'b7\'c7\'b7\'a8\'a1\'a2\'c6\'db\'d5\'a9\'a1\'a2\'b2\'bb\'b5\'b1\'bb\'f2\'c0\'c4\'d3\'c3\'b5\'c4\'c4\'bf\'b5\'c4\'bb\'f2\'d2\'d4\'c8\'ce\'ba\'ce\'bf\'c9\'c4\'dc\'b7\'c1\'b0\'ad\'c6\'e4\'cb\'fb\'d3\'c3
-\'bb\'a7\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'a3\'ac\'bb\'f2\'cb\'f0\'ba\'a6\'ce\'d2\'c3\'c7\'bb\'f2\'c6\'e4\'cb\'fb\'d3\'c3\'bb\'a7\'c8\'ce\'ba\'ce\'b2\'c6\'b2\'fa\'a3\'ac\'d2\'d4\'bc\'b0\'c7\'d6\'b7\'b8\'bb\'f2\'b7\'c1\'ba\'a6\'b5\'da\'c8\'fd
-\'b7\'bd\'c8\'ce\'ba\'ce\'c8\'a8\'c0\'fb\'b5\'c4\'b7\'bd\'ca\'bd\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'a3\'ac\'b2\'a2\'d3\'a6\'d7\'f1\'d1\'ad\'cb\'f9\loch\af13\hich\af13\dbch\f17 \'d3\'d0\'bf\'c9\'ca\'ca\'d3\'c3\'b7\'a8\'c2\'c9\'b9\'e6\'b6\'a8\'a1\'a3}
-{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 6.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c8\'e7\'b8\'f9\'be\'dd\'ce\'d2\'c3\'c7\'d7\'d4\'bc\'ba\'b5\'c4\'c5\'d0\'b6\'cf\'a3\'ac\'c8\'b7\'b6\'a8\'c4\'fa\'b6\'d4\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'ca\'b9\'d3\'c3\'a3\'ba\'a3\'a8}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 a}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'ce\'a5\'b7\'b4\'b1\'be\'d0\'ad\'d2\'e9\'b5\'c4\'c8\'ce\'ba\'ce\'b9\'e6\'b6\'a8\'a3\'bb\'a3\'a8}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 b}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'b2\'bb\'b7\'fb\'ba\'cf\'d3\'c3\'bb\'a7\'c4\'da\'c8\'dd\'b9\'e6\'b7\'b6\'a3\'bb
-\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 c}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c3\'b0\'b7\'b8\'c6\'e4\'cb\'fb\'d3\'c3\'bb\'a7\'a3\'bb\'a3\'a8}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 d}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c7\'d6\'b7\'b8\'ce\'d2\'c3\'c7\'bb\'f2\'c8\'ce\'ba\'ce\'b5\'da\'c8\'fd\'b7\'bd
-\'b5\'c4\'d6\'aa\'ca\'b6\'b2\'fa\'c8\'a8\'bb\'f2\'c6\'e4\'cb\'fb\'c8\'a8\'c0\'fb\'a3\'bb\'bb\'f2\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 e}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'d2\'d1\'be\'ad\'bb\'f2\'bf\'c9\'c4\'dc\'b5\'bc\'d6\'c2\'ce\'d2\'c3\'c7\'b3\'d0\'b5\'a3\'c8\'ce\'ba\'ce\'d4\'f0\'c8\'ce\'a3\'ac\'ce\'d2\'c3\'c7\'d3\'d0\'c8\'a8\'d4\'da\'b2\'bb\'be\'ad\'ca\'c2\'cf\'c8\'cd\'a8\'d6\'aa
-\'c7\'e9\'bf\'f6\'cf\'c2\'a3\'ba\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 i}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'d4\'dd\'cd\'a3\'bb\'f2\'d6\'d5\'d6\'b9
-\'c4\'fa\'b6\'d4\'b1\'be\'b7\'fe\'ce\'f1\'b2\'bf\'b7\'d6\'bb\'f2\'c8\'ab\'b2\'bf\'b5\'c4\'ca\'b9\'d3\'c3\'a3\'ac\'bb\'f2\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 ii}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c9\'be\'b3\'fd\'c4\'fa\'b4\'e6\'b4\'a2\'d4\'da\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'d0\'c5\'cf\'a2\'a1\'a3\'b4\'cb\'cd\'e2\'a3\'ac\'d2\'bb\'b5\'a9\'c4\'fa\'b5\'c4\'d5\'cb\'bb\'a7\'bb\'f2\'c4\'fa
-\'b7\'c3\'ce\'ca\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'c8\'a8\'c0\'fb\'b1\'bb\'d6\'d5\'d6\'b9\'a3\'ac\'ce\'d2\'c3\'c7\'bd\'ab\'bb\'e1\'c9\'be\'b3\'fd\'cb\'f9\'d3\'d0\'c4\'fa\'c9\'fa\'b3\'c9\'b5\'c4\'c4\'da\'c8\'dd\'d2\'d4\'bc\'b0\'c6\'e4\'cb\'fb\'cf\'e0
-\'b9\'d8\'d0\'c5\'cf\'a2\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 6.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'d4\'da\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'ca\'b1\'a3\'ac\'d3\'a6\'b5\'b1\'be\'a1\'ba\'cf\'c0\'ed\'b5\'c4\'d7\'a2\'d2\'e2\'a3\'ac\'b0\'fc\'c0\'a8\'c1\'cb\'bd\'e2\'bb\'a5\'c1\'aa\'ba\'cd
-\'d2\'c6\'b6\'af\'cd\'f8\'c2\'e7\'bc\'b0\'cf\'e0\'b9\'d8\'c9\'e8\loch\af13\hich\af13\dbch\f17 \'b1\'b8\'ca\'b9\'d3\'c3\'b5\'c4\'d0\'c5\'cf\'a2\'b0\'b2\'c8\'ab\'b3\'a3\'ca\'b6\'a3\'ac\'c0\'fd\'c8\'e7\'c8\'e7\'ba\'ce\'c9\'e8\'d6\'c3\'ba\'cd\'b1\'a3\'bb\'a4
-\'b0\'b2\'c8\'ab\'c3\'dc\'c2\'eb\'b5\'c8\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 6.4 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'b6\'d4\'d2\'f2\'c4\'fa\'ce\'a5\'b7\'b4\'b1\'be\'d0\'ad\'d2\'e9\'b5\'bc\'d6\'c2\'b5\'c4\'c8\'ce\'ba\'ce\'cb\'f0\'ca\'a7\'a1\'a2\'cb\'f0
-\'ba\'a6\'bc\'b0\'c6\'e4\'cb\'fb\'ba\'f3\'b9\'fb\'a3\'ac\'d3\'c9\'c4\'fa\'d7\'d4\'d0\'d0\'b8\'ba\'d4\'f0\'a1\'a3\'c4\'fa\'cd\'ac\'d2\'e2\'ce\'aa\'ce\'d2\'c3\'c7\'bc\'b0\'c6\'e4\'b9\'a9\'d3\'a6\'c9\'cc\'cc\'e1\'b9\'a9\'b2\'b9\'b3\'a5\'a1\'a2\'bf\'b9
-\'b1\'e7\'b2\'a2\'c8\'b7\'b1\'a3\'c6\'e4\'b2\'bb\'d2\'f2\'c4\'fa\'b5\'c4\'ca\'fd\'be\'dd\'a1\'a2\'c4\'fa\'b6\'d4\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'ca\'b9\'d3\'c3\'bb\'f2\'c4\'fa\'ce\'a5\'b7\'b4\'b1\'be\'d0\'ad\'d2\'e9\'cc\'f5\'bf\'ee\'cb\'f9\'b5\'bc
-\'d6\'c2\'b5\'c4\'c8\'ce\'ba\'ce\'cb\'f0\'ca\'a7\'a1\'a2\'b3\'c9\'b1\'be\'a1\'a2\'d4\'f0\'c8\'ce\'bc\'b0\'c6\'e4\'cb\'fb\'b7\'d1\'d3\'c3\'b6\'f8\'ca\'dc\'b5\'bd\'cb\'f0\'ba\'a6\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 7.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'d3\'c3
-\'bb\'a7\'ca\'fd\'be\'dd\'bc\'b0\'b4\'e6\'b4\'a2}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 7.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'b1\'be\'b7\'fe\'ce\'f1\'bf\'c9\'c4\'dc\'d4\'ca\'d0\'ed\'c4\'fa\'c9\'cf\'b4\'ab\'a1\'a2\'b4\'e6\'b4\'a2\'bb\'f2\'bd\'d3\'ca\'dc\'c4\'b3\'d0\'a9\'c4\'fa\'b5\'c4\'ca\'fd\'be\'dd\'a3\'ac\'c6\'e4\'d6\'d0\'bf\'c9\'c4\'dc\'b0\'fc\'c0\'a8\'c4\'fa\'c9\'fa
-\'b3\'c9\'b5\'c4\'c4\'da\'c8\'dd\'d2\'d4\'bc\'b0\'c4\'fa\'b5\'c4\'b8\'f6\'c8\'cb\'ca\'fd\'be\'dd\'a3\'a8\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\loch\af13\hich\af13\dbch\f17 \'a1\'b1
-\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'a1\'a3\'c4\'fa\'b6\'d4\'d5\'e2\'d0\'a9\'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\'cb\'f9\'d3\'b5\'d3\'d0\'b5\'c4\'c8\'a8\'c0\'fb\'be\'f9\'d3\'c9\'c4\'fa\'b1\'a3\'c1\'f4\'a3\'ac\'b3\'fd\'b1\'be\'d0\'ad\'d2\'e9\'c1\'ed\'d3\'d0
-\'d4\'bc\'b6\'a8\'d5\'df\'cd\'e2\'a3\'ac\'ce\'b4\'be\'ad\'c4\'fa\'ca\'c2\'cf\'c8\'cd\'ac\'d2\'e2\'a3\'ac\'ce\'d2\'c3\'c7\'b2\'bb\'bb\'e1\'d7\'d4\'bc\'ba\'bb\'f2\'d4\'ca\'d0\'ed\'cb\'fb\'c8\'cb\'ca\'b9\'d3\'c3\'c4\'fa\'b5\'c4\'d3\'c3\'bb\'a7
-\loch\af13\hich\af13\dbch\f17 \'ca\'fd\'be\'dd\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 7.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'d4\'da\'b4\'cb\'ca\'da\'d3\'e8\'ce\'d2\'c3\'c7\'d2\'bb\'b8\'f6\'c8\'ab\'c7\'f2\'b7\'b6\'ce\'a7\'b5\'c4\'a1\'a2\'b2\'bb\'bf\'c9
-\'b3\'b7\'cf\'fa\'b5\'c4\'a1\'a2\'b7\'c7\'c5\'c5\'cb\'fb\'b5\'c4\'ba\'cd\'c3\'e2\'b7\'d1\'b5\'c4\'d0\'ed\'bf\'c9\'a3\'ac\'b8\'f9\'be\'dd\'b8\'c3\'d0\'ed\'bf\'c9\'ce\'d2\'c3\'c7\'bf\'c9\'d2\'d4\'bd\'f6\'ce\'aa\'cc\'e1\'b9\'a9\'ba\'cd\'b8\'c4\'bd\'f8
-\'b7\'fe\'ce\'f1\'b5\'c4\'c4\'bf\'b5\'c4\'a3\'ac\'d7\'d4\'bc\'ba\'b2\'a2\'bf\'c9\'b7\'d6\'d0\'ed\'bf\'c9\'ce\'d2\'c3\'c7\'b5\'c4\'b7\'fe\'ce\'f1\'cc\'e1\'b9\'a9\'c9\'cc\'b8\'b4\'d6\'c6\'b2\'a2\'d2\'d4\'bc\'d3\'c3\'dc\'b7\'bd\'ca\'bd\'b4\'e6\'b4\'a2
-\'c4\'fa\'b5\'c4\'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\'a1\'a3\'c4\'fa\'d3\'a6\'c8\'b7\'b1\'a3\'c4\'fa\'d3\'b5\'d3\'d0\'cb\'f9\'d3\'d0\'b1\'d8\'d2\'aa\'b5\'c4\'c8\'a8\'c0\'fb\'ba\'cd\'c8\'a8\'c1\'a6\'ca\'da\'d3\'e8\'c9\'cf\'ca\'f6\'d0\'ed\'bf\'c9\'a1\'a3}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 7.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ce\'aa\'c4\'fa\'b5\'c4\'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\'cc\'e1\'b9\'a9\'b4\'e6\'b4\'a2\'b2\'bb\'ca\'c7\'ce\'d2\'c3\'c7\'b5\'c4\'d2\'e5\'ce\'f1\'a3\'ac\'ce\'d2\'c3\'c7\'bd\'f6\'ce\'aa\'d3\'c3\'bb\'a7
-\'b7\'bd\'b1\'e3\'b5\'c4\'c4\'bf\'b5\'c4\'cc\'e1\'b9\'a9\'b4\'cb\'cf\'ee\'b7\'fe\'ce\'f1\'a3\'ac\'ce\'aa\'b4\'cb\'a3\'ac\'c4\'fa\'d6\'aa\'b5\'c0\'b2\'a2\'cd\'ac\'d2\'e2\'a3\'ac\'ce\'d2\'c3\'c7\'bd\'ab\'b2\'bb\'b6\'d4\'ca\'fd\'be\'dd\'ce\'de\'c2\'db
-\'d2\'f2\'c8\'ce\'ba\'ce\'d4\'ad\'d2\'f2\'b1\'bb\'c9\'be\'b3\'fd\'bb\'f2\'b4\'e6\'b4\'a2\'ca\'a7\'b0\'dc\'b3\'d0\'b5\'a3\'d4\'f0\'c8\'ce\'a1\'a3\'c4\'fa\'d3\'a6\'d7\'d4\'d0\'d0\'b8\'ba\'d4\'f0\'bc\'b0\'ca\'b1\'b6\'d4\'c4\'fa\'b5\'c4\'d3\'c3\'bb\'a7
-\'ca\'fd\'be\'dd\'d7\'f6\'cd\'d7\'c9\'c6\'b5\'c4\'b1\'b8\'b7\'dd\'a1\'a3\'c4\'fa\'d6\'aa\'b5\'c0\'b2\'a2\'cd\'ac\'d2\'e2\'a3\'ac\'ce\'d2\'c3\'c7\'bf\'c9\'c4\'dc\'bb\'e1\'b6\'d4\'c4\'fa\'c9\'cf\'b4\'ab\'bb\'f2\'b4\'e6\'b4\'a2\'b5\'c4\'d3\'c3\'bb\'a7
-\'ca\'fd\'be\'dd\'b5\'c4\'ca\'fd\'c1\'bf\'ba\'cd\'c6\'da\'cf\'de\'c9\'e8\'d6\'c3\'cf\'de\'d6\'c6\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 7\hich\af13\dbch\af17\loch\f13 .4 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'c9\'fa\'b3\'c9\'b5\'c4\'c4\'da\'c8\'dd\'b0\'fc\'c0\'a8\'b5\'ab\'bf\'c9\'c4\'dc\'b2\'bb\'cf\'de
-\'d3\'da\'c4\'fa\'b4\'b4\'c9\'e8\'b5\'c4\'ea\'c7\'b3\'c6\'bb\'f2\'d3\'c3\'bb\'a7\'c3\'fb\'a3\'ac\'d2\'d4\'bc\'b0\'c4\'fa\'b4\'e6\'b4\'a2\'b5\'c4\'d3\'ef\'d2\'f4\'d7\'ca\'c1\'cf\'bc\'b0\'c6\'e4\'cb\'fb\'c4\'da\'c8\'dd\'a1\'a3\'c4\'fa\'d3\'a6\'c8\'b7
-\'b1\'a3\'c4\'fa\'c9\'fa\'b3\'c9\'b5\'c4\'c4\'da\'c8\'dd\'b2\'bb\'b5\'c3\'d6\'b1\'bd\'d3\'bb\'f2\'bc\'e4\'bd\'d3\'ba\'ac\'d3\'d0\'c8\'ce\'ba\'ce\'a3\'ba\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 1}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'d2\'f9\'bb\'e0\'a1\'a2\'d4\'ec\'d2\'a5\'a1\'a2\'b7\'cc\'b0\'f9\'a1\'a2\'da\'ae\'bb\'d9\'a1\'a2\'d6\'d0\'c9\'cb\'a1\'a2\'d9\'f4\'e4\'c2\'a1\'a2\'d3\'d0\'c9\'cb\'b7\'e7
-\'bb\'af\'d2\'d4\'bc\'b0\'c6\'e4\'cb\'fb\'ce\'a5\'b7\'b4\'b9\'ab\'d0\'f2\'c1\'bc\'cb\'d7\'bc\'b0\'b5\'b1\'b5\'d8\'b7\'a8\'c2\'c9\'ba\'cd\'d5\'fe\'b2\'df\'b5\'c4\'c4\'da\'c8\'dd\'a3\'bb\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\hich\af13\dbch\af17\loch\f13 2}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c7\'d6\'b7\'b8\'bb\'f2\'c0\'c4\'d3\'c3\'b5\'da\'c8\'fd\'b7\'bd\'d6\'aa\'ca\'b6\'b2\'fa\'c8\'a8\'a1\'a2\'c3\'fb\'d3\'fe\'c8\'a8
-\'a1\'a2\'c9\'f9\'d3\'fe\'c8\'a8\'a1\'a2\'d2\'fe\'cb\'bd\'c8\'a8\'bc\'b0\'c6\'e4\'cb\'fb\'ba\'cf\'b7\'a8\'c8\'a8\'c0\'fb\'b5\'c4\'c4\'da\'c8\'dd\'a3\'bb\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 3}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'d0\'fb\'d1\'ef\'b1\'a9\'c1\'a6\'a1\'a2\'b9\'fa\'bc\'d2\'ba\'cd\'c3\'f1\'d7\'e5\'b7\'d6\'c1\'d1\'a1\'a2\'c3\'f1\'d7\'e5\'b3\'f0\'ba\'de\'ba\'cd\'b7\'c1\'b0\'ad\'c3\'f1
-\'d7\'e5\'cd\'c5\'bd\'e1\'b5\'c4\'c4\'da\'c8\'dd\'a3\'bb\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 4}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'d0\'fb\'d1\'ef
-\'d5\'eb\'b6\'d4\'c4\'b3\'d0\'a9\'b8\'f6\'c8\'cb\'bb\'f2\'cd\'c5\'cc\'e5\'c6\'e7\'ca\'d3\'a1\'a2\'b3\'f0\'ba\'de\'d1\'d4\'c2\'db\'b5\'c4\'c4\'da\'c8\'dd\'a3\'ac\'ce\'de\'c2\'db\'ca\'c7\'bb\'f9\'d3\'da\'d6\'d6\'d7\'e5\'a1\'a2\'d0\'d4\'b1\'f0\'a1\'a2
-\'b9\'fa\'bc\'ae\'a1\'a2\'d7\'da\'bd\'cc\'d0\'c5\'d1\'f6\'a1\'a2\'d0\'d4\'c8\'a1\'cf\'f2\'bb\'f2\'b4\'cb\'c0\'e0\'b8\'f6\'c8\'cb\'bb\'f2\'cd\'c5\'cc\'e5\'b5\'c4\'d3\'ef\'d1\'d4\'a3\'bb\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\hich\af13\dbch\af17\loch\f13 5}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c8\'ce\'ba\'ce\'b9\'e3\'b8\'e6\'d0\'fb\'b4\'ab\'d2\'d4\'bc\'b0\'d5\'d0\'c0\'bf\'bb\'f2\'cd\'c6\loch\af13\hich\af13\dbch\f17 \'bd\'e9
-\'c9\'cc\'d2\'b5\'bb\'fa\'bb\'e1\'b5\'c4\'c4\'da\'c8\'dd\'a3\'bb\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 6}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c8\'ce
-\'ba\'ce\'c9\'bf\'b6\'af\'a1\'a2\'d7\'e9\'d6\'af\'a1\'a2\'bd\'cc\'cb\'f4\'bb\'f2\'d0\'fb\'b4\'ab\'b7\'c7\'b7\'a8\'bb\'ee\'b6\'af\'b5\'c4\'c4\'da\'c8\'dd\'a3\'bb\'d2\'d4\'bc\'b0\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\hich\af13\dbch\af17\loch\f13 7}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'c8\'ce\'ba\'ce\'b7\'a8\'c2\'c9\'bb\'f2\'d5\'fe\'b2\'df\'bd\'fb\'d6\'b9\'b5\'c4\'a3\'ac\'bb\'f2\'b8\'f9\'be\'dd\'d3\'d0\'b9\'dc
-\'cf\'bd\'c8\'a8\'b5\'c4\'cb\'be\'b7\'a8\'bb\'f2\'d6\'b4\'b7\'a8\'bb\'fa\'b9\'d8\'b5\'c4\'c5\'d0\'be\'f6\'a1\'a2\'b2\'c3\'b6\'a8\'a1\'a2\'c3\'fc\'c1\'ee\'a1\'a2\'cd\'a8\'d6\'aa\'bb\'f2\'d6\'b8\'ca\'be\'bd\'fb\'d6\'b9\'cc\'e1\'b9\'a9\'b5\'c4\'c4\'da
-\'c8\'dd\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 8.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'d2\'fe
-\'cb\'bd\'c8\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ce\'d2\'c3\'c7\'b6\'d4\'c4\'fa\'b5\'c4\'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\'b5\'c4\'ca\'d5
-\'bc\'af\'a1\'a2\'ca\'b9\'d3\'c3\'a1\'a2\'b4\'e6\'b4\'a2\'ba\'cd\'b4\'a6\'c0\'ed\'a3\'ac\'bd\'ab\'b7\'fb\'ba\'cf\'ce\'d2\'c3\'c7\'b9\'ab\'b2\'bc\'b5\'c4\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d2\'fe\'cb\'bd\'c8\'a8\'d5\'fe
-\'b2\'df\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'b5\'c4\'b9\'e6\'b6\'a8\'a1\'a3\'c4\'fa\'cd\'ac\'d2\'e2\'ce\'d2\'c3\'c7\'bf\'c9\'d2\'d4\'b0\'b4\'d5\'d5\'ce\'d2\'c3\'c7\'b5\'c4\'d2\'fe\'cb\'bd\'c8\'a8\'d5\'fe\'b2\'df\'ce\'aa
-\'cc\'e1\'b9\'a9\'ba\'cd\'b8\'c4\'c9\'c6\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'c4\'bf\'b5\'c4\'a3\'ac\'d2\'d4\'bc\'b0\'c6\'e4\'cb\'fb\'ce\'d2\'c3\'c7\'ca\'c2\'cf\'c8\'b8\'e6\'d6\'aa\'b5\'c4\'d3\'c3\'cd\'be\'a3\'ac\'ca\'d5\'bc\'af\'a1\'a2\'ca\'b9\'d3\'c3
-\'a1\'a2\'b4\'e6\'b4\'a2\'ba\'cd\'b4\'a6\'c0\'ed\'c4\'fa\'b5\'c4\'d3\'c3\'bb\'a7\'ca\'fd\'be\'dd\'a1\'a3\'c4\'fa\'bf\'c9\'d4\'da\'c9\'e8\'b1\'b8\'bb\'f2\'c8\'ed\'bc\'fe\'b5\'c4\'bc\'a4\'bb\'ee\'b5\'e3\'bb\'f2\loch\af13\hich\af13\dbch\f17 \'a1\'b0
-\loch\af13\hich\af13\dbch\f17 \'c9\'e8\'d6\'c3\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'d6\'d0\'b2\'e9\'d5\'d2\'b2\'a2\'d4\'c4\'b6\'c1\'ce\'d2\'c3\'c7\'b5\'c4\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 
-\'d2\'fe\'cb\'bd\'c8\'a8\'d5\'fe\'b2\'df\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'ac\'c1\'cb\'bd\'e2\'ce\'d2\'c3\'c7\'ca\'d5\'bc\'af\'a1\'a2\'ca\'b9\'d3\'c3\'a1\'a2\'b4\'e6\'b4\'a2\'ba\'cd\'b4\'a6\'c0\'ed\'c4\'fa\'b5\'c4
-\'b8\'f6\'c8\'cb\'ca\'fd\'be\'dd\'b5\'c4\'cf\'e0\'b9\'d8\'d5\'fe\loch\af13\hich\af13\dbch\f17 \'b2\'df\'cf\'ea\'c7\'e9\'a1\'a3\'c4\'fa\'d2\'b2\'bf\'c9\'b5\'c7\'c2\'bc\'ce\'d2\'c3\'c7\'b5\'c4\'cd\'f8\'d5\'be\'c1\'aa\'bb\'fa\'d4\'c4\'b6\'c1\'d4\'da\'cf\'df
-\'b0\'e6\'b1\'be\'b5\'c4\'a1\'b6\'d2\'fe\'cb\'bd\'c8\'a8\'d5\'fe\'b2\'df\'a1\'b7\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 9.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'b7\'fe
-\'ce\'f1\'b7\'d1\'d3\'c3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ca\'b9\'d3\'c3\'c4\'b3\'d0\'a9\'b7\'fe\'ce\'f1\'bf\'c9\'c4\'dc\'d0\'e8\'d2\'aa\'c4\'fa
-\'c1\'ed\'cd\'e2\'d6\'a7\'b8\'b6\'b7\'d1\'d3\'c3\'a3\'ac\'be\'df\'cc\'e5\'b0\'b4\'cf\'e0\'b9\'d8\'b7\'fe\'ce\'f1\'cc\'f5\'bf\'ee\'d6\'b4\'d0\'d0\'a1\'a3\'ce\'d2\'c3\'c7\'b1\'a3\'c1\'f4\'b6\'d4\'b7\'fe\'ce\'f1\'ca\'d5\'c8\'a1\'b7\'d1\'d3\'c3\'bc\'b0
-\'b8\'c4\'b1\'e4\'ca\'d5\'b7\'d1\'b1\'ea\'d7\'bc\'ba\'cd\'ca\'d5\'b7\'d1\'b7\'bd\'ca\'bd\'b5\'c4\'c8\'a8\'c0\'fb\'a1\'a3\'b3\'fd\'d2\'d4\'d0\'c5\'d3\'c3\'bf\'a8\'a1\'a2\'bd\'e8\'bc\'c7\'bf\'a8\'bb\'f2\'b5\'e7\'d7\'d3\'d6\'a7\'b8\'b6\'b7\'bd\'ca\'bd
-\'bd\'f8\'d0\'d0\'b5\'c4\'bd\'bb\'d2\'d7\'cd\'e2\'a3\'ac\'b7\'d1\'d3\'c3\'d3\'a6\'d4\'da\'ca\'d5\'b5\'bd\'b8\'b6\'bf\'ee\'cd\'a8\'d6\'aa\'ca\'b1\'b5\'bd\'c6\'da\'d3\'a6\'b8\'b6\'a3\'ac\'c4\'fa\'cd\'ac\'d2\'e2\'d6\'a7\'b8\'b6\'b8\'b6\'bf\'ee\'cd\'a8
-\'d6\'aa\'c9\'cf\'d6\'b8\'c3\'f7\'b5\'c4\'b7\'d1\'d3\'c3\'a3\'ac\'b0\'fc\'c0\'a8\'c8\'ce\'ba\'ce\'bf\'c9\'ca\'ca\'d3\'c3\'b5\'c4\'cb\'b0\'bf\'ee\'ba\'cd\'d6\'cd\'c4\'c9\'bd\'f0\'a1\'a3\'c4\'fa\'d7\'d4\'d0\'d0\'b8\'ba\'d4\'f0\'d6\'a7\'b8\'b6\'d3\'eb
-\'b7\'fe\'ce\'f1\'cf\'e0\'b9\'d8\'b5\'c4\'cb\'b0\'bf\'ee\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 10.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'b2\'bb\'b1\'a3\'d6\'a4\'c9\'f9\'c3\'f7}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'c0\'ed\'bd\'e2\'b2\'a2\'cd\'ac\'d2\'e2\'a3\'ac\'b3\'fd\'b7\'c7\'c1\'ed\'d3\'d0
-\'ce\'d2\'c3\'c7\'c3\'f7\'c8\'b7\'a3\'ac\'b7\'f1\'d4\'f2\'b1\'be\'b7\'fe\'ce\'f1\'be\'f9\'d2\'d4\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'b0\'b4\'cf\'d6\'d7\'b4\loch\af13\hich\af13\dbch\f17 \'a1\'b1
-\loch\af13\hich\af13\dbch\f17 \'c7\'d2\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'bf\'c9\'d3\'c3\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'ce\'aa\'bb\'f9\'b4\'a1\'cc\'e1\'b9\'a9\'a3\'ac\'d4\'da\'b7\'a8
-\'c2\'c9\'d4\'ca\'d0\'ed\'b5\'c4\'d7\'ee\'b4\'f3\'cf\'de\'b6\'c8\'c4\'da\'a3\'ac\'ce\'d2\'c3\'c7\'bd\'ab\'b2\'bb\'be\'cd\'c8\'ed\'bc\'fe\'bb\'f2\'b7\'fe\'ce\'f1\'d7\'f7\'b3\'f6\'c8\'ce\loch\af13\hich\af13\dbch\f17 \'ba\'ce\'b1\'a3\'d6\'a4\'a3\'ac\'ce\'de
-\'c2\'db\'ca\'c7\'c3\'f7\'ca\'be\'b5\'c4\'bb\'b9\'ca\'c7\'c4\'ac\'ca\'be\'b5\'c4\'a3\'ac\'b0\'fc\'c0\'a8\'b5\'ab\'b2\'bb\'cf\'de\'d3\'da\'d3\'d0\'b9\'d8\'ca\'ca\'cf\'fa\'d0\'d4\'a1\'a2\'ca\'ca\'d3\'c3\'d3\'da\'cc\'d8\'b6\'a8\'c4\'bf\'b5\'c4\'a1\'a2
-\'b2\'bb\'c7\'d6\'c8\'a8\'b5\'c4\'c4\'ac\'ca\'be\'b1\'a3\'d6\'a4\'a1\'a3\'ce\'d2\'c3\'c7\'b2\'bb\'b1\'a3\'d6\'a4\'b1\'be\'b7\'fe\'ce\'f1\'bd\'ab\'ce\'de\'d6\'d0\'b6\'cf\'a1\'a2\'bc\'b0\'ca\'b1\'a1\'a2\'b0\'b2\'c8\'ab\'bb\'f2\'9b\'5d\'d3\'d0\'c8\'ce
-\'ba\'ce\'b4\'ed\'ce\'f3\'b5\'d8\'d4\'cb\'d0\'d0\'a3\'ac\'d2\'d4\'bc\'b0\'b1\'be\'b7\'fe\'ce\'f1\'d6\'d0\'b5\'c4\'cb\'f9\'d3\'d0\'b4\'ed\'ce\'f3\'be\'f9\'bd\'ab\'b1\'bb\'be\'c0\'d5\'fd\'a1\'a3\'b3\'fd\'b7\'c7\'c1\'ed\'d3\'d0\'ca\'e9\'c3\'e6\'cb\'b5
-\'c3\'f7\'a3\'ac\'b7\'f1\'d4\'f2\'a3\'ac\'ce\'d2\'c3\'c7\'b2\'bb\'b1\'a3\'d6\'a4\'bd\'ab\'be\'cd\'b1\'be\'b7\'fe\'ce\'f1\'cc\'e1\'b9\'a9\'bc\'bc\'ca\'f5\'d6\'a7\'b3\'d6\'a1\'a3\'d2\'d4\'c9\'cf\'c5\'c5\'b3\'fd\'d2\'b2\'ca\'ca\'d3\'c3\'d3\'da\'b1\'be
-\'b7\'fe\'ce\'f1\'b5\'c4\'bf\'aa\'b7\'a2\'d5\'df\'a1\'a2\'b9\'a9\'d3\'a6\'c9\'cc\'bc\'b0\'cf\'fa\'ca\'db\'c9\'cc\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 11.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'d4\'f0\'c8\'ce\'cf\'de\'d6\'c6}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ce\'de\'c2\'db\'d4\'da\'c8\'ce\'ba\'ce\'c7\'e9\'bf\'f6\'cf\'c2\'a3\'ac\'ce\'d2\'c3\'c7
-\'be\'f9\'b2\'bb\'be\'cd\'c8\'ce\'ba\'ce\'cc\'d8\'b1\'f0\'b5\'c4\'a1\'a2\'bc\'e4\'bd\'d3\'b5\'c4\'a1\'a2\'c5\'bc\'c8\'bb\'b5\'c4\'a1\'a2\'bd\'e1\'b9\'fb\'d0\'d4\'b5\'c4\'bb\'f2\'b3\'cd\'b7\'a3\'d0\'d4\'b5\'c4\'cb\'f0\'ba\'a6\'c5\'e2\'b3\'a5\'b6\'d4
-\'c4\'fa\'bb\'f2\'b5\'da\'c8\'fd\'b7\'bd\'b3\'d0\'b5\'a3\'c8\'ce\'ba\'ce\'d4\'f0\'c8\'ce\'a3\'ac\'ce\'de\'c2\'db\'d5\'e2\'d0\'a9\'d4\'f0\'c8\'ce\'ca\'c7\'d2\'f2\'ba\'cf\'cd\'ac\'a1\'a2\'b1\'a3\'d6\'a4\'a1\'a2\'c7\'d6\'c8\'a8\'a3\'a8\'b0\'fc\'c0\'a8
-\'ca\'e8\'ba\'f6\'bb\'f2\'d1\'cf\'b8\'f1\'d4\'f0\'c8\'ce\'a3\'a9\'bb\'f2\'c8\'ce\'ba\'ce\'c6\'e4\'cb\'fb\'d4\'f0\'c8\'ce\'d4\'ad\'c0\'ed\'b2\'fa\'c9\'fa\'a3\'ac\'bc\'b4\'ca\'b9\'ce\'d2\'c3\'c7\'ca\'c2\'cf\'c8\'d2\'d1\'be\'ad\'b1\'bb\'b8\'e6
-\loch\af13\hich\af13\dbch\f17 \'d6\'aa\'b4\'cb\'c0\'e0\'cb\'f0\'ba\'a6\'b7\'a2\'c9\'fa\'b5\'c4\'bf\'c9\'c4\'dc\'d0\'d4\'bb\'f2\'b4\'cb\'c0\'e0\'cb\'f0\'ba\'a6\'b5\'c4\'b7\'a2\'c9\'fa\'bf\'c9\'d2\'d4\'b1\'bb\'ce\'d2\'c3\'c7\'ba\'cf\'c0\'ed\'d4\'a4\'bc\'fb
-\'a1\'a3\'ce\'d2\'c3\'c7\'be\'cd\'c8\'ce\'ba\'ce\'ba\'cd\'cb\'f9\'d3\'d0\'cb\'f0\'ba\'a6\'c5\'e2\'b3\'a5\'cb\'f9\'b3\'d0\'b5\'a3\'c8\'ab\'b2\'bf\'d4\'f0\'c8\'ce\'a3\'ac\'bd\'ab\'d2\'d4\'d2\'fd\'b7\'a2\'cf\'e0\'b9\'d8\'cb\'df\'cb\'cf\'bb\'f2\'cb\'f7
-\'c5\'e2\'b5\'c4\'ca\'c2\'bc\'fe\'ca\'d7\'b4\'ce\'b7\'a2\'c9\'fa\'c8\'d5\'d6\'ae\'c7\'b0\'d2\'bb\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 1}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'b8\'f6\'d4\'c2\'ce\'d2\'c3\'c7\'be\'cd\'b7\'fe\'ce\'f1\'cf\'f2\'c4\'fa\'cb\'f9\'ca\'d5\'c8\'a1\'b7\'fe\'ce\'f1\'b7\'d1\'d7\'dc\'b6\'ee\'bb\'f2\'d2\'bb\'b0\'d9\'a3\'a8}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 100}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'a3\'a9\'d4\'aa\'ce\'aa\'cf\'de\'a3\'ac\'d2\'d4\'bd\'cf\'b8\'df\'d5\'df\'ce\'aa\'d7\'bc\'a1\'a3\'b1\'be\'cc\'f5\'bf\'ee
-\'b5\'c4\'d4\'f0\'c8\'ce\'cf\'de\'d6\'c6\'b7\'b4\'d3\'b3\'c1\'cb\'b1\'be\'d0\'ad\'d2\'e9\'b5\'b1\'ca\'c2\'c8\'cb\'c3\'f7\'c8\'b7\'cd\'ac\'d2\'e2\'b5\'c4\'b7\'e7\'cf\'d5\'b7\'d6\'cc\'af\'a1\'a3\'b1\'be\'cc\'f5\'bf\'ee\'b9\'e6\'b6\'a8\'b5\'c4\'cf\'de
-\'d6\'c6\'bd\'ab\'ca\'ca\'d3\'c3\'d3\'da\'c8\'ce\'ba\'ce\'ba\'cd\'cb\'f9\'d3\'d0\'c7\'e9\'bf\'f6\'a3\'ac\'b0\'fc\'c0\'a8\'b7\'fe\'ce\'f1\'b5\'c4\'bf\'aa\'b7\'a2\'c9\'cc\'a1\'a2\'b9\'a9\'d3\'a6\'c9\'cc\'ba\'cd\'cf\'fa\'ca\'db\'c9\'cc\'a3\'ac\'b2\'a2
-\'d4\'da\'b1\'be\'d0\'ad\'d2\'e9\'d6\'d5\'d6\'b9\'ba\'f3\'bc\'cc\'d0\'f8\'d3\'d0\'d0\'a7\'a1\'a3\'d3\'d0\'d0\'a9\'cb\'be\'b7\'a8\'b9\'dc\'cf\'bd\'c7\'f8\'b5\'c4\'b7\'a8\'c2\'c9\'b2\'bb\'d4\'ca\'d0\'ed\'c4\'b3\'d0\'a9\'d4\'f0\'c8\'ce\'cf\'de\'d6\'c6
-\'a3\'ac\'d5\'e2\'d6\'d6\'c7\'e9\'bf\'f6\'cf\'c2\'c9\'cf\'ca\'f6\'c4\'b3\'d0\'a9\'cf\'de\'d6\'c6\'bd\'ab\'b2\'bb\'ca\'ca\'d3\'c3\'d3\'da\'c4\'fa\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 12.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'cf\'fb\'b7\'d1\'d5\'df\'c8\'a8\'c0\'fb}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'b1\'be\'d0\'ad\'d2\'e9\'b5\'c4\'c8\'ce\'ba\'ce\'b9\'e6\'b6\'a8\'be\'f9\'b2\'bb\'d3\'b0
-\'cf\'ec\'b2\'bb\'c4\'dc\'cd\'a8\'b9\'fd\'ba\'cf\'cd\'ac\'d3\'e8\'d2\'d4\'b7\'c5\loch\af13\hich\af13\dbch\f17 \'c6\'fa\'bb\'f2\'cf\'de\'d6\'c6\'b5\'c4\'cf\'fb\'b7\'d1\'d5\'df\'b5\'c4\'c8\'ce\'ba\'ce\'b7\'a8\'b6\'a8\'c8\'a8\'c0\'fb\'a1\'a3\'b8\'f9\'be\'dd
-\'cf\'e0\'b9\'d8\'b7\'a8\'c2\'c9\'b9\'e6\'b6\'a8\'a3\'ac\'c4\'fa\'bf\'c9\'c4\'dc\'bb\'b9\'d3\'b5\'d3\'d0\'b2\'bb\'c4\'dc\'cd\'a8\'b9\'fd\'b1\'be\'d0\'ad\'d2\'e9\'b8\'c4\'b1\'e4\'b5\'c4\'c6\'e4\'cb\'fb\'c8\'a8\'c0\'fb\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 13.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'b5\'da\'c8\'fd\'b7\'bd\'c8\'ed\'bc\'fe\'ba\'cd\'b7\'fe\'ce\'f1}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'c1\'cb\'bd\'e2\'a3\'ac\'b1\'be\'b7\'fe\'ce\'f1\'b5\'c4\'c4\'b3\'d0\'a9\'b9\'a6
-\'c4\'dc\'bb\'f2\'d7\'e9\'bc\'fe\'bf\'c9\'c4\'dc\'d3\'c9\'b5\'da\'c8\'fd\'b7\'bd\'cc\'e1\'b9\'a9\'a1\'a3\'b7\'fe\'ce\'f1\'d3\'c3\'bb\'a7\'bd\'e7\'c3\'e6\'c9\'cf\'bf\'c9\'c4\'dc\'cc\'e1\'b9\'a9\'b6\'d4\'b5\'da\'c8\'fd\'b7\'bd\'cd\'f8\'d5\'be\'b5\'c4
-\'c1\'b4\'bd\'d3\'a3\'ac\'c4\'fa\'b5\'e3\'bb\'f7\'d5\'e2\'d0\'a9\'c1\'b4\'bd\'d3\'bb\'e1\'bd\'f8\'c8\'eb\'b7\'c7\'d3\'c9\'ce\'d2\'c3\'c7\'d4\'cb\'d3\'aa\'a1\'a2\'b9\'dc\'c0\'ed\'ba\'cd\'d6\'a7\'b3\'d6\'b5\'c4\'b5\'da\'c8\'fd\'b7\'bd\'cd\'f8\'d5\'be
-\'a1\'a3\'b5\'da\'c8\'fd\'b7\'bd\'c8\'ed\'bc\'fe\'bb\'f2\'b7\'fe\'ce\'f1\'bd\'ab\'bb\'f9\'d3\'da\'c6\'e4\'b6\'c0\'c1\'a2\'b5\'c4\'d0\'ed\'bf\'c9\'d0\'ad\'d2\'e9\'a1\'a2\'b7\'fe\'ce\'f1\'cc\'f5\'bf\'ee\'ba\'cd\'d2\'fe\'cb\'bd\'c8\'a8\'d5\'fe\'b2\'df
-\'cc\'e1\'b9\'a9\'a3\'ac\'d5\'e2\'d0\'a9\'cc\'f5\'bf\'ee\'bf\'c9\'c4\'dc\'d3\'eb\'ce\'d2\'c3\'c7\'b5\'c4\'b9\'e6\'b6\'a8\'d3\'d0\'b2\'ee\'d2\'ec\'a1\'a3\'c4\'fa\'cd\'a8\'b9\'fd\'b5\'da\'c8\'fd\'b7\'bd\'c8\'ed\'bc\'fe\'bb\'f2\'b7\'fe\'ce\'f1\'cc\'e1
-\'bd\'bb\'b5\'c4\'bb\'f2\'d3\'c9\'c6\'e4\'ca\'d5\'bc\'af\'b5\'c4\'c4\'fa\'b5\'c4\'b8\'f6\'c8\'cb\'d0\'c5\'cf\'a2\'a3\'ac\'b2\'bb\'ca\'ca\'d3\'c3\'ce\'d2\'c3\'c7\'b5\'c4\'d2\'fe\'cb\'bd\'c8\'a8\'d5\'fe\'b2\'df\'a1\'a3\'c8\'e7\'c4\'fa\'d1\'a1\'d4\'f1
-\'ca\'b9\'d3\'c3\'b5\'da\'c8\'fd\'b7\'bd\'c8\'ed\'bc\'fe\'bb\'f2\'b7\'fe\'ce\'f1\'a3\'ac\'c7\'eb\'c4\'fa\'d7\'d0\'cf\'b8\'d4\'c4\'b6\'c1\'b8\'c3\'b5\'da\'c8\'fd\'b7\'bd\'b5\'c4\'cf\'e0\'b9\'d8\'b7\'a8\'c2\'c9\'cc\'f5\'bf\'ee\'a1\'a3\'b3\'fd\'b7\'c7
-\loch\af13\hich\af13\dbch\f17 \'c1\'ed\'d3\'d0\'c3\'f7\'c8\'b7\'cb\'b5\'c3\'f7\'a3\'ac\'b7\'f1\'d4\'f2\'a3\'ac\'ce\'d2\'c3\'c7\'b2\'bb\'b6\'d4\'b5\'da\'c8\'fd\'b7\'bd\'c8\'ed\'bc\'fe\'bb\'f2\'b7\'fe\'ce\'f1\'bc\'b0\'c6\'e4\'c4\'da\'c8\'dd\'d7\'f6\'c8\'ce
-\'ba\'ce\'b3\'c2\'ca\'f6\'ba\'cd\'b1\'a3\'d6\'a4\'a3\'ac\'b0\'fc\'c0\'a8\'b5\'ab\'b2\'bb\'cf\'de\'d3\'da\'c6\'e4\'bf\'c9\'bb\'f1\'b5\'c3\'d0\'d4\'ba\'cd\'b3\'d6\'d0\'f8\'d0\'d4\'a1\'a3\'b5\'da\'c8\'fd\'b7\'bd\'bf\'c9\'c4\'dc\'bb\'e1\'be\'cd\'c6\'e4
-\'c8\'ed\'bc\'fe\'bb\'f2\'b7\'fe\'ce\'f1\'cc\'e1\'b9\'a9\'d7\'d4\'bc\'ba\'b5\'c4\'b1\'a3\'d6\'a4\'a1\'a3\'c4\'fa\'c0\'ed\'bd\'e2\'b2\'a2\'cd\'ac\'d2\'e2\'a3\'ac\'c4\'fa\'bd\'ab\'bb\'f9\'d3\'da\'d7\'d4\'bc\'ba\'b5\'c4\'c5\'d0\'b6\'cf\'b2\'a2\'d7\'d4
-\'d0\'d0\'b3\'d0\'b5\'a3\'b7\'e7\'cf\'d5\'c0\'b4\'be\'f6\'b6\'a8\'ca\'b9\'d3\'c3\'d5\'e2\'d0\'a9\'b5\'da\'c8\'fd\'b7\'bd\'c8\'ed\'bc\'fe\'bb\'f2\'b7\'fe\'ce\'f1\'bc\'b0\'c6\'e4\'c4\'da\'c8\'dd\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 14.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'d3\'aa\'cf\'fa\'b2\'c4\'c1\'cf\'ba\'cd\'cd\'c6\'b9\'e3\'b7\'fe\'ce\'f1}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ce\'d2\'c3\'c7\'bf\'c9\'c4\'dc\'bb\'e1\'b2\'bb\'ca\'b1\'cf\'f2\'c4\'fa\'b7\'a2\'cb\'cd
-\'d2\'bb\'d0\'a9\'d3\'aa\'cf\'fa\'b2\'c4\'c1\'cf\'d2\'d4\'bc\'b0\'ce\'aa\'c4\'fa\'cc\'e1\'b9\'a9\'b8\'bd\'bc\'d3\'b5\'c4\'cd\'c6\'b9\'e3\'b7\'fe\'ce\'f1\'a3\'ac\'b6\'f8\'b2\'bb\'bb\'e1\'be\'cd\'b4\'cb\'c1\'ed\'d0\'d0\'cf\'f2\'c4\'fa\'ca\'d5\'c8\'a1
-\'b7\'d1\'d3\'c3\'a3\'a8\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'cd\'c6\'b9\'e3\'b7\'fe\'ce\'f1\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'a3\'a9\'a1\'a3\'c4\'fa\'d6\'aa\'b5\'c0\'b2\'a2\'cd\'ac
-\'d2\'e2\'a3\'ac\'ce\'d2\'c3\'c7\'bf\'c9\'d2\'d4\'cd\'a8\'b9\'fd\'b5\'e7\'d7\'d3\'b4\'ab\'ca\'e4\'a1\'a2\'b5\'e7\'d7\'d3\'d3\'ca\'bc\'fe\'a1\'a2\'d0\'c5\'ba\'af\'bb\'f2\'c6\'e4\'cb\'fb\'b7\'bd\'ca\'bd\'cf\'f2\'c4\'fa\'b7\'a2\'cb\'cd\'c9\'cf\'ca\'f6
-\'d3\'aa\'cf\'fa\'ba\'cd\'cd\'c6\'b9\'e3\'b2\'c4\'c1\'cf\'a1\'a3\'c4\'fa\'bf\'c9\'cb\'e6\'ca\'b1\'cd\'a8\'d6\'aa\'ce\'d2\'c3\'c7\'cd\'a3\'d6\'b9\'b7\'a2\'cb\'cd\'c9\'cf\'ca\'f6\'b2\'c4\'c1\'cf\'a1\'a3\'c4\'fa\'c1\'cb\'bd\'e2\'b2\'a2\'cd\'ac\'d2\'e2
-\'ce\'d2\'c3\'c7\'bf\'c9\'c4\'dc\'bb\'e1\'b2\'bb\'be\'ad\loch\af13\hich\af13\dbch\f17 \'c1\'ed\'d0\'d0\'cd\'a8\'d6\'aa\'cb\'e6\'ca\'b1\'b5\'f7\'d5\'fb\'ce\'d2\'c3\'c7\'cc\'e1\'b9\'a9\'c9\'cf\'ca\'f6\'cd\'c6\'b9\'e3\'b7\'fe\'ce\'f1\'b5\'c4\'b7\'b6\'ce\'a7
-\'a3\'ac\'c4\'b3\'d0\'a9\'cd\'c6\'b9\'e3\'b7\'fe\'ce\'f1\'bf\'c9\'c4\'dc\'bd\'f6\'d5\'eb\'b6\'d4\'d0\'c2\'bf\'cd\'bb\'a7\'a3\'ac\'c4\'fa\'bf\'c9\'c4\'dc\'b2\'a2\'b2\'bb\'c4\'dc\'bb\'f1\'b5\'c3\'c4\'b3\'d0\'a9\'bb\'f2\'cb\'f9\'d3\'d0\'c9\'cf\'ca\'f6
-\'cd\'c6\'b9\'e3\'b7\'fe\'ce\'f1\'a1\'a3\'c8\'e7\'b9\'fb\'c4\'fa\'bb\'f1\'b5\'c3\'c1\'cb\'ce\'d2\'c3\'c7\'cc\'e1\'b9\'a9\'b5\'c4\'c8\'ce\'ba\'ce\'cd\'c6\'b9\'e3\'bb\'f2\'cc\'d8\'b1\'f0\'bc\'db\'b8\'f1\'bb\'f2\'cc\'f5\'bc\'fe\'a3\'ac\'d5\'e2\'d0\'a9
-\'bc\'db\'b8\'f1\'bb\'f2\'cc\'f5\'bc\'fe\'bd\'f6\'ca\'ca\'d3\'c3\'d3\'da\'c4\'fa\'a3\'ac\'c4\'fa\'d3\'a6\'b6\'d4\'d5\'e2\'d0\'a9\'bc\'db\'b8\'f1\'ba\'cd\'cc\'f5\'bc\'fe\'b1\'a3\'c3\'dc\'a3\'ac}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'ce\'b4\'be\'ad\'ce\'d2\'c3\'c7\'ca\'c2
-\'cf\'c8\'ca\'e9\'c3\'e6\'c3\'f7\'c8\'b7\'cd\'ac\'d2\'e2\'a3\'ac\'c4\'fa\'b2\'bb\'b5\'c3\'bd\'ab\'b4\'cb\'c0\'e0\'d0\'c5\'cf\'a2\'c5\'fb\'c2\'b6\'b8\'f8\'c8\'ce\'ba\'ce\'b5\'da\'c8\'fd\'b7\'bd\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 15.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'b1\'be\'d0\'ad\'d2\'e9\'b5\'c4\'b1\'e4\'b8\'fc\'ba\'cd\'d6\'d5\'d6\'b9}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 15.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'ce\'d2\'c3\'c7\'bf\'c9\'d2\'d4\'cb\'e6\'ca\'b1\'b8\'fc\'b8\'c4\'b1\'be\'d0\'ad\'d2\'e9\'cc\'f5\'bf\'ee\'a1\'a3\'ce\'d2\'c3\'c7\'bf\'c9\'c4\'dc\'bb\'e1\'cd\'a8\'b9\'fd\'ce\'d2\'c3\'c7\'b5\'c4\'cd\'f8\'d5\'be\'a1\'a2\'bf\'cd\'bb\'a7\'b6\'cb\'b9\'ab
-\'b8\'e6\'bb\'f2\'c6\'e4\'cb\'fb\'b7\'bd\'ca\'bd\'b8\'e6\'d6\'aa\'d5\'e2\'d0\'a9\'d0\'de\'b8\'c4\'a1\'a3\'c4\'fa\'cd\'ac\'d2\'e2\'a3\'ac\'b7\'a2\'b2\'bc\'b4\'cb\'c0\'e0\'b8\'fc\'b8\'c4\'ba\'f3\'a3\'ac\'c8\'e7\'c4\'fa\'bc\'cc\'d0\'f8\'ca\'b9\'d3\'c3
-\'b1\'be\'b7\'fe\'ce\'f1\'bc\'b4\'b1\'ed\'c3\'f7\'c4\'fa\'bd\'d3\'ca\'dc\'d0\'de\'b8\'c4\'ba\'f3\'b5\'c4\'d0\'ad\'d2\'e9\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 15.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'bf\'c9\'d2\'d4\'cd\'a8\'b9\'fd\'b8\'f9\'be\'dd\'cf\'e0\'b9\'d8\'d6\'b8\'ca\'be\'c9\'be\'b3\'fd\'c8\'ed\'bc\'fe
-\loch\af13\hich\af13\dbch\f17 \'a1\'a2\'b9\'d8\'b1\'d5\'d5\'cb\'ba\'c5\'bc\'b0\'cd\'a3\'d6\'b9\'ca\'b9\'d3\'c3\'b7\'fe\'ce\'f1\'b5\'c8\'b7\'bd\'ca\'bd\'cb\'e6\'ca\'b1\'d6\'d5\'d6\'b9\'b1\'be\'d0\'ad\'d2\'e9\'a1\'a3\'ce\'d2\'c3\'c7\'b8\'f9\'be\'dd\'b1\'be
-\'d0\'ad\'d2\'e9\'d4\'bc\'b6\'a8\'c8\'a1\'cf\'fb\'c8\'ab\'b2\'bf\'b7\'fe\'ce\'f1\'ca\'b1\'b1\'be\'d0\'ad\'d2\'e9\'d6\'d5\'d6\'b9\'a1\'a3\'cb\'ab\'b7\'bd\'be\'f9\'b2\'bb\'d0\'e8\'ce\'aa\'b4\'cb\'b3\'d0\'b5\'a3\'c8\'ce\'ba\'ce\'d4\'f0\'c8\'ce\'a1\'a3}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 15.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c8\'e7\'b7\'a2\'cf\'d6\'c4\'fa\'d5\'fd\'d4\'da\'ce\'aa\'c8\'ce\'ba\'ce\'ce\'b4\'be\'ad\'d4\'ca\'d0\'ed\'b5\'c4\'bb\'f2\'b1\'be\'d0\'ad
-\'d2\'e9\'bd\'fb\'d6\'b9\'b5\'c4\'d3\'c3\'cd\'be\'ca\'b9\'d3\'c3\'b1\'be\'b7\'fe\'ce\'f1\'a3\'ac\'bb\'f2\'c8\'e7\'c4\'fa\'b5\'c4\'d0\'d0\'ce\'aa\'bb\'f2\'d7\'b4\'cc\'ac\'ca\'b9\'ce\'d2\'c3\'c7\'d3\'d0\'c0\'ed\'d3\'c9\'c8\'cf\'ce\'aa\'bc\'cc\'d0\'f8
-\'cf\'f2\'c4\'fa\'cc\'e1\'b9\'a9\'b7\'fe\'ce\'f1\'bf\'c9\'c4\'dc\'b8\'f8\'ce\'d2\'c3\'c7\'b4\'f8\'c0\'b4\'bd\'cf\'b4\'f3\'b7\'e7\'cf\'d5\'b5\'c4\'a3\'ac\'ce\'d2\'c3\'c7\'bf\'c9\'b8\'f9\'be\'dd\'d7\'d4\'bc\'ba\'b5\'c4\'c5\'d0\'b6\'cf\'d6\'d5\'d6\'b9
-\'b1\'be\'d0\'ad\'d2\'e9\'a3\'ac\'b2\'a2\'be\'cd\'b7\'fe\'ce\'f1\'ca\'b9\'d3\'c3\'b7\'d1\'bc\'b0\'d2\'f2\'c4\'fa\'b2\'bb\'b5\'b1\'ca\'b9\'d3\'c3\'b5\'bc\'d6\'c2\'b5\'c4\'cb\'f0\'ca\'a7\'cf\'f2\'c4\'fa\'cb\'f7\'c5\'e2\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 15.4 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'cd\'ac\'d2\'e2\'a3\'ac\'b1\'be\'d0\'ad\'d2\'e9\'d6\'d5\'d6\'b9\'ba\'f3\'a3\'ac\'c4\'fa\'d3\'a6\'cf\'fa\'bb\'d9\'c8\'ed\'bc\'fe
-\'b2\'a2\'d3\'c0\'be\'c3\'d0\'d4\'b5\'d8\'c9\'be\'b3\'fd\'c6\'e4\'cb\'f9\'d3\'d0\'b1\'b8\'b7\'dd\'a3\'ac\'b2\'a2\'c7\'d2\'c4\'fa\'ca\'b9\'d3\'c3\'b7\'fe\'ce\'f1\'b5\'c4\'c8\'a8\'c0\'fb\'d2\'b2\'bd\'ab\'c1\'a2\'bc\'b4\'d6\'d5\'d6\'b9\'a1\'a3}{\rtlch\fcs1 
-\af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 15.5 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'b1\'be\'d0\'ad\'d2\'e9\'b1\'ea\'cc\'e2\'ce\'aa\loch\af13\hich\af13\dbch\f17 \'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d0\'ed\'bf\'c9
-\'ba\'cd\'cf\'de\'d6\'c6\loch\af13\hich\af13\dbch\f17 \'a1\'b1\'a1\'b0\loch\af13\hich\af13\dbch\f17 \'ce\'de\'b1\'a3\'d6\'a4\'c9\'f9\'c3\'f7\loch\af13\hich\af13\dbch\f17 \'a1\'b1\'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d4\'f0\'c8\'ce\'cf\'de\'d6\'c6
-\loch\af13\hich\af13\dbch\f17 \'a1\'b1\'a1\'b0\loch\af13\hich\af13\dbch\f17 \'d2\'bb\'b0\'e3\'cc\'f5\'bf\'ee\loch\af13\hich\af13\dbch\f17 \'a1\'b1\loch\af13\hich\af13\dbch\f17 \'bc\'b0\'c6\'e4\'cb\'fb\'d2\'c0\'be\'dd\'c6\'e4\'d0\'d4\'d6\'ca\'ca\'bc
-\'d6\'d5\'d3\'d0\'d0\'a7\'b5\'c4\'cc\'f5\'bf\'ee\'d4\'da\'b1\'be\'d0\'ad\'d2\'e9\'d6\'d5\'d6\'b9\'ba\'f3\'bc\'cc\'d0\'f8\'d3\'d0\'d0\'a7\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \hich\af13\dbch\af17\loch\f13 16.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'d2\'bb\'b0\'e3\'cc\'f5\'bf\'ee}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 16.1 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 
-\'b1\'be\'d0\'ad\'d2\'e9\'d2\'c0\'d6\'d0\'bb\'aa\'c8\'cb\'c3\'f1\'b9\'b2\'ba\'cd\'b9\'fa\'b4\'f3\'c2\'bd\'cb\'be\'b7\'a8\'b9\'dc\'cf\'bd\'c7\'f8\'a3\'a8\'ce\'aa\'c3\'f7\'c8\'b7\'c6\'f0\'bc\'fb\'a3\'ac\'b2\'bb\'b0\'fc\'c0\'a8\'cf\'e3\'b8\'db\'cc\'d8
-\'b1\'f0\'d0\'d0\'d5\'fe\'c7\'f8\'a1\'a2\'b0\'c4\'c3\'c5\'cc\'d8\'b1\'f0\'d0\'d0\'d5\'fe\'c7\'f8\'ba\'cd\'cc\'a8\'cd\'e5\'b5\'d8\'c7\'f8\'a3\'a9\'b5\'c4\'bf\'c9\'ca\'ca\'d3\'c3\'b7\'a8\'c2\'c9\'d6\'c6\'b6\'a8\'ba\'cd\'bd\'e2\'ca\'cd\'a1\'a3\'d3\'c9
-\'b1\'be\'d0\'ad\'d2\'e9\'d2\'fd\'c6\'f0\'b5\'c4\'bb\'f2\'d3\'eb\'d6\'ae\'cf\'e0\'b9\'d8\'b5\'c4\'c8\'ce\'ba\'ce\'d5\'f9\'d2\'e9\'a3\'ac\'d3\'a6\'ca\'d7\'cf\'c8\'cd\'a8\'b9\'fd\'d3\'d1\'ba\'c3\'d0\'ad\'c9\'cc\'bd\'e2\'be\'f6\'a3\'ac\'d0\'ad\'c9\'cc
-\'b2\'bb\'b3\'c9\'b5\'c4\'a3\'ac\'d3\'c9\'ce\'d2\'c3\'c7\'cb\'f9\'d4\'da\'b5\'d8\'b5\'c4\'b7\'a8\'d4\'ba\'d7\'a8\'ca\'f4\'b9\'dc\'cf\'bd\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 16.2 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'b1\'be\'d0\'ad\'d2\'e9\'bd\'e1\'ba\'cf\'d2\'fe\'cb\'bd\'c8\'a8\'d5\'fe\'b2\'df\'bc\'b0\'d4\'ae\'d2\'fd\'b5\'c4\'c6\'e4\'cb\'fb\'cc\'d8
-\'b1\'f0\'cc\'f5\'bf\'ee\'b9\'b9\'b3\'c9\'c4\'fa\'d3\'eb\'ce\'d2\'c3\'c7\'d6\'ae\'bc\'e4\'be\'cd\'b1\'be\'b7\'fe\'ce\'f1\'cb\'f9\'b4\'ef\'b3\'c9\'b5\'c4\'c8\'ab\'b2\'bf\'d0\'ad\'d2\'e9\'a3\'ac\'b2\'a2\'c8\'a1\'b4\'fa\'cb\'f9\'d3\'d0\'c6\'e4\'cb\'fb
-\'b5\'c4\'b9\'b5\'cd\'a8\'bb\'f2\'bd\'bb\'c1\'f7\'a3\'ac\'ce\'de\'c2\'db\'ca\'c7\'bf\'da\'cd\'b7\'b5\'c4\'bb\'b9\'ca\'c7\'ca\'e9\'c3\'e6\'b5\'c4\'a1\'a3\'b3\'fd\'b7\'c7\'b1\'be\'d0\'ad\'d2\'e9\'c1\'ed\'d3\'d0\'d4\'bc\'b6\'a8\'a3\'ac\'b6\'d4\'b1\'be
-\'d0\'ad\'d2\'e9\'b5\'c4\'c8\'ce\'ba\'ce\'d0\'de\'b8\'c4\'be\'f9\'d3\'a6\'d2\'d4\'ca\'e9\'c3\'e6\loch\af13\hich\af13\dbch\f17 \'b2\'b9\'b3\'e4\'d0\'ad\'d2\'e9\'d0\'ce\'ca\'bd\'bd\'f8\'d0\'d0\'b7\'bd\'ce\'aa\'d3\'d0\'d0\'a7\'a1\'a3\'ce\'d2\'c3\'c7\'ce\'b4
-\'d0\'d0\'ca\'b9\'bb\'f2\'c7\'bf\'d6\'c6\'d6\'b4\'d0\'d0\'b0\'fc\'ba\'ac\'d4\'da\'b1\'be\'d0\'ad\'d2\'e9\'d6\'d0\'b5\'c4\'c8\'ce\'ba\'ce\'c8\'a8\'c0\'fb\'bb\'f2\'cc\'f5\'bf\'ee\'a3\'ac\'b2\'bb\'ca\'d3\'ce\'aa\'b6\'d4\'cf\'e0\'b9\'d8\'c8\'a8\'c0\'fb
-\'ba\'cd\'cc\'f5\'bf\'ee\'b5\'c4\'b7\'c5\'c6\'fa\'a1\'a3\'c8\'e7\'b1\'be\'d0\'ad\'d2\'e9\'b5\'c4\'c8\'ce\'ba\'ce\'b9\'e6\'b6\'a8\'bb\'f2\'b2\'bf\'b7\'d6\'b1\'bb\'d3\'d0\'b9\'dc\'cf\'bd\'c8\'a8\'b5\'c4\'b2\'c3\'c5\'d0\'bb\'fa\'b9\'b9\'c5\'d0\'b6\'a8
-\'ce\'aa\'b2\'bb\'bf\'c9\'c7\'bf\'d6\'c6\'d6\'b4\'d0\'d0\'a3\'ac\'b2\'bb\'d3\'b0\'cf\'ec\'b1\'be\'d0\'ad\'d2\'e9\'b5\'c4\'c6\'e4\'cb\'fb\'b2\'bf\'b7\'d6\'b5\'c4\'d0\'a7\'c1\'a6\'a3\'ac\'b1\'be\'d0\'ad\'d2\'e9\'c6\'e4\'cb\'fb\'b2\'bf\'b7\'d6\'c8\'d4
-\'bc\'cc\'d0\'f8\'d3\'d0\'d0\'a7\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par \hich\af13\dbch\af17\loch\f13 16.3 }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c4\'fa\'cd\'ac\'d2\'e2\'ce\'d2\'c3\'c7\'ce\'aa\'c2\'c4\'d0\'d0\'b1\'be\'d0\'ad\'d2\'e9\'b5\'c4\'c4\'bf\'b5\'c4\'a3\'ac\'bf\'c9\'cd\'a8
-\'b9\'fd\'b5\'e7\'d7\'d3\'d3\'ca\'bc\'fe\'a1\'a2\'ca\'d6\'bb\'fa\'b6\'cc\'d0\'c5\'a1\'a2\'cf\'fb\'cf\'a2\'b5\'af\'b4\'b0\'bb\'f2\'c6\'e4\'cb\'fb\'d0\'c5\'bc\'fe\'b4\'ab\'cb\'cd\'b5\'c8\'b7\'bd\'ca\'bd\'cf\'f2\'c4\'fa\'b7\'a2\'cb\'cd\'cd\'a8\'d6\'aa
-\'a3\'bb\'cd\'ac\'ca\'b1\'a3\'ac\'b1\'be\'d0\'ad\'d2\'e9\'cf\'ee\'cf\'c2\'ce\'d2\'c3\'c7\'b6\'d4\'d3\'da\'d3\'c3\'bb\'a7\'cb\'f9\'d3\'d0\'b5\'c4\'cd\'a8\'d6\'aa\'d2\'b2\'bf\'c9\'cd\'a8\'b9\'fd\'cd\'f8\'d2\'b3\'b9\'ab\'b8\'e6\'b7\'bd\'ca\'bd\'bd\'f8
-\'d0\'d0\'a3\'bb\'b8\'c3\'b5\'c8\'cd\'a8\'d6\'aa\'d3\'da\'b7\'a2\'cb\'cd\'d6\'ae\'c8\'d5\'ca\'d3\'ce\'aa\'d2\'d1\'cb\'cd\'b4\'ef\'ca\'d5\'bc\'fe\'c8\'cb\'a1\'a3\'c4\'fa\'cf\'f2\'ce\'d2\'c3\'c7\'b7\'a2\'cb\'cd\'b5\'c4\'cd\'a8\'d6\'aa\'d3\'a6\'b5\'b1
-\'cd\'a8\'b9\'fd\'ce\'d2\'c3\'c7\'b6\'d4\'cd\'e2\'d5\'fd\'ca\'bd\'b9\'ab\'b2\'bc\'b5\'c4\'cd\'a8\'d0\'c5\'b5\'d8\'d6\'b7\'a1\'a2\'b5\'e7\'d7\'d3\'d3\'ca\'bc\'fe\'b5\'d8\'d6\'b7\'b5\'c8\'cb\'cd\'b4\'ef\'a1\'a3}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid8347566 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 {\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c8\'e7\'be\'cd\'b1\'be\'d0\'ad\'d2\'e9
-\'c4\'da\'c8\'dd\'a3\'ac\'c4\'fa\'d3\'d0\'c8\'ce\'ba\'ce\'ce\'ca\'cc\'e2\'a1\'a2\'d2\'e2\'bc\'fb\'bb\'f2\'bd\'a8\'d2\'e9\'a3\'ac\'c4\'fa\'bf\'c9\'cd\'a8\'b9\'fd\'d2\'d4\'cf\'c2\'b7\'bd\'ca\'bd\'d3\'eb\'ce\'d2\'c3\'c7\'c1\'aa\'cf\'b5\'a3\'ba\'b7\'a2
-\'cb\'cd\'b5\'e7\'d7\'d3\'d3\'ca\'bc\'fe\'d6\'c1\'a3\'ba}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 kefu@creality.com
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c9\'ee\'db\'da\'ca\'d0\'b4\'b4\'cf\'eb\'c8\'fd\'ce\'ac\'bf\'c6\'bc\'bc}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid726032 \loch\af13\hich\af13\dbch\f17 \'b9\'c9\'b7\'dd}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'d3\'d0\'cf\'de\'b9\'ab\'cb\'be}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \loch\af13\hich\af13\dbch\f17 \'c9\'ee\'db\'da\'ca\'d0\'c1\'fa\'bb\'aa\'c7\'f8\'c3\'f1\'d6\'ce\'bd\'d6\'b5\'c0\'d0\'c2\'c5\'a3\'c9\'e7\'c7\'f8\'c3\'b7\'c1\'fa\'b4\'f3\'b5\'c0\'bd\'f5\'d0\'e5\'ba\'e8
-\'b6\'bc\'b4\'f3\'cf\'c3}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 \hich\af13\dbch\af17\loch\f13 18F}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid8347566 
-\par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
-9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
-5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
-b01d583deee5f99824e290b4ba3f364eac4a430883b3c092d4eca8f946c916422ecab927f52ea42b89a1cd59c254f919b0e85e6535d135a8de20f20b8c12c3b0
-0c895fcf6720192de6bf3b9e89ecdbd6596cbcdd8eb28e7c365ecc4ec1ff1460f53fe813d3cc7f5b7f020000ffff0300504b030414000600080000002100a5d6
-a7e7c0000000360100000b0000005f72656c732f2e72656c73848fcf6ac3300c87ef85bd83d17d51d2c31825762fa590432fa37d00e1287f68221bdb1bebdb4f
-c7060abb0884a4eff7a93dfeae8bf9e194e720169aaa06c3e2433fcb68e1763dbf7f82c985a4a725085b787086a37bdbb55fbc50d1a33ccd311ba548b6309512
-0f88d94fbc52ae4264d1c910d24a45db3462247fa791715fd71f989e19e0364cd3f51652d73760ae8fa8c9ffb3c330cc9e4fc17faf2ce545046e37944c69e462
-a1a82fe353bd90a865aad41ed0b5b8f9d6fd010000ffff0300504b0304140006000800000021006b799616830000008a0000001c0000007468656d652f746865
-6d652f7468656d654d616e616765722e786d6c0ccc4d0ac3201040e17da17790d93763bb284562b2cbaebbf600439c1a41c7a0d29fdbd7e5e38337cedf14d59b
-4b0d592c9c070d8a65cd2e88b7f07c2ca71ba8da481cc52c6ce1c715e6e97818c9b48d13df49c873517d23d59085adb5dd20d6b52bd521ef2cdd5eb9246a3d8b
-4757e8d3f729e245eb2b260a0238fd010000ffff0300504b030414000600080000002100e96c4e8db4060000ab1b0000160000007468656d652f7468656d652f
-7468656d65312e786d6cec594f6f134714bf57ea7718ed1d62277688231c143b36692110c5868ae3783dde1d32bbb39a1927f886e08854a92aad3814a9eaa587
-aa2d1248ad54fa651a4a45a9c457e89b99ddf54ebc6e1288286a891089677ff3febfdfbc599fbf702b62688f084979dcf4aa672b1e22b1cf87340e9adeb57ef7
-cc8a87a4c2f110331e93a63721d2bbb0f6e107e7f1aa0a494410ec8fe52a6e7aa152c9eac282f46119cbb33c21313c1b711161051f45b03014781fe4466c61b1
-52595e88308d3d14e308c45e1d8da84fd0b39f7f79f1cd83df6edf837fde5aa6a3c34051aca45ef099e8690dc4d968b0c3ddaa46c8896c3381f6306b7aa06ec8
-f7fbe496f210c352c183a657313fdec2daf905bc9a6e626acedec2beaef949f7a51b86bb8b46a70806b9d26ab7d638b791cb3700a666719d4ea7dda9e6f20c00
-fb3e786a6d29caac7557aaad4c660164ff9c95ddaed42b35175f90bf346373a3d56ad51ba92d56a801d93f6b33f895ca726d7dd1c11b90c5d767f0b5d67abbbd
-ece00dc8e29767f0dd738de59a8b37a090d1787706ad13daeda6d273c888b3cd52f80ac0572a297c8a826ac8ab4bab18f158cdabb508dfe4a20b000d6458d118
-a9494246d887626ee3682028d60af02ac1852776c997334b5a1792bea0896a7a1f27181a632aefd5d3ef5f3d7d8c0eee3c39b8f3d3c1ddbb07777eb4829c5d9b
-380e8abb5e7efbd95f0f6fa33f1f7ffdf2fe17e57859c4fffec3bd67bf7e5e0e84f6999af3fccb477f3c79f4fcc1a72fbebb5f025f17785084f7694424ba42f6
-d10e8fc0311315d772321027dbd10f312dee588f038963acb594c8efa8d0415f99609666c7b1a345dc085e17401f65c08be39b8ec1bd508c152dd17c298c1ce0
-16e7acc54569142e695d8530f7c77150ae5c8c8bb81d8cf7ca74b771ece4b7334e8037b3b2741c6f87c431739be158e180c44421fd8cef1252e2dd0d4a9db86e
-515f70c9470adda0a885696948fa74e054d374d3268d202f93329f21df4e6cb6aea31667655e6f903d17095d815989f17dc29c305ec46385a332917d1cb162c0
-2f63159619d99b08bf88eb4805990e08e3a833245296edb92ac0df42d22f6160acd2b46fb149e42285a2bb65322f63ce8bc80dbedb0e719494617b340e8bd88f
-e42e942846db5c95c1b7b8db21fa33e401c773d37d9d1227dd47b3c1351a38264d0b443f198b925c5e24dca9dfde848d30315403a4ee707544e37f226e4681b9
-ad86d3236ea0cae75f3d2cb1fb5da5ec7538bdca7a66f31051cfc31da6e7361743faeeb3f3061ec7db041a62f6887a4fceefc9d9fbcf93f3bc7e3e7d4a9eb230
-10b49e45eca06dc6ee68eed43da28cf5d48491cbd20cde12ce9e611716f53e73f124f92d2c09e14fddc9a0c0c105029b3d4870f50955612fc4090ced554f0b09
-642a3a9028e1122e8b66b954b6c6c3e0afec55b3ae2f21963924565b7c689797f47276d7c8c518ab0273a1cd142d6901c755b6742e150abebd8eb2aa36ead8da
-aac634438a8eb6dc651d6273298790e7aec1621e4d186a108c4210e565b8fa6bd570d9c18c0c75dc6d8eb2b4982c9c668a64888724cd91f67b36475593a4ac56
-661cd17ed862d017c723a256d0d6d062df40db71925454579ba32ecbde9b6429abe0699640dae1766471b139598cf69b5ea3be58f7908f93a637827b32fc1925
-9075a9e748cc0278e7e42b61cbfec866365d3ecd662373cc6d822abcfab0719f71d8e1814448b58165684bc33c4a4b80c55a93b57fb10e613d2d074ad8e87856
-2cad4031fc6b56401cddd492d188f8aa98ecc28a8e9dfd9852291f2b227ae1701f0dd858ec6048bf2e55f0674825bcee308ca03fc0bb391d6df3c825e7b4e98a
-6fc40cceae63968438a55bdda259275bb821a4dc06f3a9601ef8566abb71eee4ae98963f25578a65fc3f73459f27f0f66169a833e0c31b628191ee94a6c7850a
-39b0501252bf2b607030dc01d502ef77e1311415bca736bf05d9d3bf6dcf5919a6ade112a97668800485f3488582906da025537d4708aba6679715c95241a6a2
-0ae6cac49a3d207b84f535072eebb3dd432194ba619394060cee70fdb99fd30e1a047ac829f69bc364f9d96b7be06d4f3eb699c1299787cd4093c53f37311f0f
-a6a7aadd6fb667676fd111fd603a66d5b2ae006585a3a091b6fd6b9a70c2a3d632d68cc78bf5cc38c8e2acc7b0980f4409bc4342fa3f38ffa8f0193165ac0fd4
-3edf016e45f0e58516066503557dc60e1e4813a45d1cc0e064176d31695136b4e9e8a4a3961dd6a73ce9e67a0f055b5b769c7c9f30d8f970e6aa737af134839d
-46d889b55d9b1b6ac8ece11685a5517691318931df9615bfc9e2839b90e80df8ce60cc9434c504df53090c3374cff40134bfd568b6aefd0d0000ffff0300504b
-0304140006000800000021000dd1909fb60000001b010000270000007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72
-656c73848f4d0ac2301484f78277086f6fd3ba109126dd88d0add40384e4350d363f2451eced0dae2c082e8761be9969bb979dc9136332de3168aa1a083ae995
-719ac16db8ec8e4052164e89d93b64b060828e6f37ed1567914b284d262452282e3198720e274a939cd08a54f980ae38a38f56e422a3a641c8bbd048f7757da0
-f19b017cc524bd62107bd5001996509affb3fd381a89672f1f165dfe514173d9850528a2c6cce0239baa4c04ca5bbabac4df000000ffff0300504b01022d0014
-000600080000002100e9de0fbfff0000001c0200001300000000000000000000000000000000005b436f6e74656e745f54797065735d2e786d6c504b01022d00
-14000600080000002100a5d6a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c73504b01022d0014000600080000
-0021006b799616830000008a0000001c00000000000000000000000000190200007468656d652f7468656d652f7468656d654d616e616765722e786d6c504b01
-022d0014000600080000002100e96c4e8db4060000ab1b00001600000000000000000000000000d60200007468656d652f7468656d652f7468656d65312e786d
-6c504b01022d00140006000800000021000dd1909fb60000001b0100002700000000000000000000000000be0900007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73504b050600000000050005005d010000b90a00000000}
-{\*\colorschememapping 3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d22796573223f3e0d0a3c613a636c724d
-617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
-6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
-656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax267\lsdlockeddef0\lsdsemihiddendef1\lsdunhideuseddef1\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 1;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 2;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;
-\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;
-\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdpriority39 \lsdlocked0 toc 1;\lsdpriority39 \lsdlocked0 toc 2;\lsdpriority39 \lsdlocked0 toc 3;\lsdpriority39 \lsdlocked0 toc 4;\lsdpriority39 \lsdlocked0 toc 5;\lsdpriority39 \lsdlocked0 toc 6;
-\lsdpriority39 \lsdlocked0 toc 7;\lsdpriority39 \lsdlocked0 toc 8;\lsdpriority39 \lsdlocked0 toc 9;\lsdsemihidden0 \lsdlocked0 header;\lsdsemihidden0 \lsdqformat1 \lsdlocked0 footer;\lsdqformat1 \lsdpriority35 \lsdlocked0 caption;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority10 \lsdlocked0 Title;\lsdpriority1 \lsdlocked0 Default Paragraph Font;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority11 \lsdlocked0 Subtitle;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority22 \lsdlocked0 Strong;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority20 \lsdlocked0 Emphasis;\lsdsemihidden0 \lsdunhideused0 \lsdlocked0 Normal (Web);
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority59 \lsdlocked0 Table Grid;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 No Spacing;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 List Paragraph;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 Quote;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 Intense Quote;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority19 \lsdlocked0 Subtle Emphasis;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority21 \lsdlocked0 Intense Emphasis;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority31 \lsdlocked0 Subtle Reference;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority32 \lsdlocked0 Intense Reference;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority33 \lsdlocked0 Book Title;\lsdpriority37 \lsdlocked0 Bibliography;
-\lsdqformat1 \lsdpriority39 \lsdlocked0 TOC Heading;}}{\*\datastore 0105000002000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
-d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000007066
-0dce4a84d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
-000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
-0000000000000000000000000000000000000000000000000105000000000000}}
+\pard\widctlpar\sb100\sa100\b0\f0\fs24\'d6\'d8\'d2\'aa\'cc\'e1\'d0\'d1\'a3\'ba\'d4\'da\'cf\'c2\'d4\'d8\'a1\'a2\'b0\'b2\'d7\'b0\'ba\'cd\'ca\'b9\'d3\'c3\'b4\'b4\'cf\'eb\'c8\'fd\'ce\'ac\'bf\'c6\'bc\'bc\'b9\'c9\'b7\'dd\'d3\'d0\'cf\'de\'b9\'ab\'cb\'be\'c8\'ed\'bc\'fe\'ba\'cd\'b7\'fe\'ce\'f1\'c7\'b0\'a3\'ac\'c7\'eb\'ce\'f1\'b1\'d8\'d7\'d0\'cf\'b8\'d4\'c4\'b6\'c1\'b1\'be\'d0\'ad\'d2\'e9\'a1\'a3\f1\par
+\f0 GNU AFFERO GENERAL PUBLIC LICENSE\par
+Version 3, 19 November 2007\par
+\par
+Copyright \f2\'a9 2007 Free Software Foundation, Inc. <{{\field{\*\fldinst{HYPERLINK "https://fsf.org/"}}{\fldrslt{https://fsf.org/\ul0\cf0}}}}\f2\fs24 >\par
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.\par
+\par
+Preamble\par
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.\par
+\par
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.\par
+\par
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.\par
+\par
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.\par
+\par
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate. Many developers of free software are heartened and encouraged by the resulting cooperation. However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.\par
+\par
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community. It requires the operator of a network server to provide the source code of the modified version running there to the users of that server. Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.\par
+\par
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals. This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.\par
+\par
+The precise terms and conditions for copying, distribution and modification follow.\par
+\par
+TERMS AND CONDITIONS\par
+0. Definitions.\par
+"This License" refers to version 3 of the GNU Affero General Public License.\par
+\par
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.\par
+\par
+"The Program" refers to any copyrightable work licensed under this License. Each licensee is addressed as "you". "Licensees" and "recipients" may be individuals or organizations.\par
+\par
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.\par
+\par
+A "covered work" means either the unmodified Program or a work based on the Program.\par
+\par
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.\par
+\par
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.\par
+\par
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.\par
+\par
+1. Source Code.\par
+The "source code" for a work means the preferred form of the work for making modifications to it. "Object code" means any non-source form of a work.\par
+\par
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.\par
+\par
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.\par
+\par
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.\par
+\par
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.\par
+\par
+The Corresponding Source for a work in source code form is that same work.\par
+\par
+2. Basic Permissions.\par
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.\par
+\par
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.\par
+\par
+Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.\par
+\par
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.\par
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.\par
+\par
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.\par
+\par
+4. Conveying Verbatim Copies.\par
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.\par
+\par
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.\par
+\par
+5. Conveying Modified Source Versions.\par
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:\par
+\par
+a) The work must carry prominent notices stating that you modified it, and giving a relevant date.\par
+b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to "keep intact all notices".\par
+c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.\par
+d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.\par
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.\par
+\par
+6. Conveying Non-Source Forms.\par
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:\par
+\par
+a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.\par
+b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.\par
+c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.\par
+d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.\par
+e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.\par
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.\par
+\par
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.\par
+\par
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.\par
+\par
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).\par
+\par
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.\par
+\par
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.\par
+\par
+7. Additional Terms.\par
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.\par
+\par
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.\par
+\par
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:\par
+\par
+a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or\par
+b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or\par
+c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or\par
+d) Limiting the use for publicity purposes of names of licensors or authors of the material; or\par
+e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or\par
+f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.\par
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.\par
+\par
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.\par
+\par
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.\par
+\par
+8. Termination.\par
+You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).\par
+\par
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.\par
+\par
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.\par
+\par
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.\par
+\par
+9. Acceptance Not Required for Having Copies.\par
+You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.\par
+\par
+10. Automatic Licensing of Downstream Recipients.\par
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.\par
+\par
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.\par
+\par
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.\par
+\par
+11. Patents.\par
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's "contributor version".\par
+\par
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.\par
+\par
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.\par
+\par
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.\par
+\par
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.\par
+\par
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.\par
+\par
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.\par
+\par
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.\par
+\par
+12. No Surrender of Others' Freedom.\par
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.\par
+\par
+13. Remote Network Interaction; Use with the GNU General Public License.\par
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software. This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.\par
+\par
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.\par
+\par
+14. Revised Versions of this License.\par
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.\par
+\par
+Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.\par
+\par
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.\par
+\par
+Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.\par
+\par
+15. Disclaimer of Warranty.\par
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\par
+\par
+16. Limitation of Liability.\par
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.\par
+\par
+17. Interpretation of Sections 15 and 16.\par
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.\par
+\par
+END OF TERMS AND CONDITIONS\par
+\par
+How to Apply These Terms to Your New Programs\par
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.\par
+\par
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.\par
+\par
+    <one line to give the program's name and a brief idea of what it does.>\par
+    Copyright (C) <year>  <name of author>\par
+\par
+    This program is free software: you can redistribute it and/or modify\par
+    it under the terms of the GNU Affero General Public License as\par
+    published by the Free Software Foundation, either version 3 of the\par
+    License, or (at your option) any later version.\par
+\par
+    This program is distributed in the hope that it will be useful,\par
+    but WITHOUT ANY WARRANTY; without even the implied warranty of\par
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\par
+    GNU Affero General Public License for more details.\par
+\par
+    You should have received a copy of the GNU Affero General Public License\par
+    along with this program.  If not, see <{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f2\fs24 >.\par
+Also add information on how to contact you by electronic and paper mail.\par
+\par
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source. For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code. There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.\par
+\par
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f2\fs24 >.\f0\par
+}
+ 

--- a/license_en.rtf
+++ b/license_en.rtf
@@ -1,462 +1,218 @@
-{\rtf1\adeflang1025\ansi\ansicpg936\uc2\adeff0\deff0\stshfdbch17\stshfloch0\stshfhich0\stshfbi0\deflang1033\deflangfe2052\themelang1033\themelangfe2052\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}
-{\f13\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}\'cb\'ce\'cc\'e5{\*\falt \'cb\'ce\'cc\'e5};}{\f17\fbidi \fmodern\fcharset134\fprq1{\*\panose 02010609060101010101}\'ba\'da\'cc\'e5{\*\falt \'ba\'da\'cc\'e5};}
-{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}{\f38\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}@\'cb\'ce\'cc\'e5;}
-{\f39\fbidi \fmodern\fcharset134\fprq1{\*\panose 02010609060101010101}@\'ba\'da\'cc\'e5;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}
-{\fdbmajor\f31501\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}\'cb\'ce\'cc\'e5{\*\falt \'cb\'ce\'cc\'e5};}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
-{\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}
-{\fdbminor\f31505\fbidi \fnil\fcharset134\fprq2{\*\panose 02010600030101010101}\'cb\'ce\'cc\'e5{\*\falt \'cb\'ce\'cc\'e5};}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
-{\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman{\*\falt Times New Roman};}{\f352\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\f353\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\f355\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\f356\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\f357\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\f358\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\f359\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\f360\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}{\f484\fbidi \fnil\fcharset0\fprq2 SimSun Western{\*\falt \'cb\'ce\'cc\'e5};}{\f524\fbidi \fmodern\fcharset0\fprq1 SimHei Western{\*\falt \'ba\'da\'cc\'e5};}
-{\f692\fbidi \froman\fcharset238\fprq2 Cambria Math CE;}{\f693\fbidi \froman\fcharset204\fprq2 Cambria Math Cyr;}{\f695\fbidi \froman\fcharset161\fprq2 Cambria Math Greek;}{\f696\fbidi \froman\fcharset162\fprq2 Cambria Math Tur;}
-{\f699\fbidi \froman\fcharset186\fprq2 Cambria Math Baltic;}{\f700\fbidi \froman\fcharset163\fprq2 Cambria Math (Vietnamese);}{\f734\fbidi \fnil\fcharset0\fprq2 @\'cb\'ce\'cc\'e5 Western;}{\f744\fbidi \fmodern\fcharset0\fprq1 @\'ba\'da\'cc\'e5 Western;}
-{\flomajor\f31508\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}{\flomajor\f31509\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}
-{\flomajor\f31511\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}{\flomajor\f31512\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}
-{\flomajor\f31513\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}{\flomajor\f31514\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}
-{\flomajor\f31515\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}{\flomajor\f31516\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}
-{\fdbmajor\f31520\fbidi \fnil\fcharset0\fprq2 SimSun Western{\*\falt \'cb\'ce\'cc\'e5};}{\fhimajor\f31528\fbidi \froman\fcharset238\fprq2 Cambria CE;}{\fhimajor\f31529\fbidi \froman\fcharset204\fprq2 Cambria Cyr;}
-{\fhimajor\f31531\fbidi \froman\fcharset161\fprq2 Cambria Greek;}{\fhimajor\f31532\fbidi \froman\fcharset162\fprq2 Cambria Tur;}{\fhimajor\f31535\fbidi \froman\fcharset186\fprq2 Cambria Baltic;}
-{\fhimajor\f31536\fbidi \froman\fcharset163\fprq2 Cambria (Vietnamese);}{\fbimajor\f31538\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\fbimajor\f31539\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\fbimajor\f31541\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\fbimajor\f31542\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\fbimajor\f31543\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\fbimajor\f31544\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\fbimajor\f31545\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\fbimajor\f31546\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}{\flominor\f31548\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\flominor\f31549\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\flominor\f31551\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\flominor\f31552\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\flominor\f31553\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\flominor\f31554\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\flominor\f31555\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\flominor\f31556\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}{\fdbminor\f31560\fbidi \fnil\fcharset0\fprq2 SimSun Western{\*\falt \'cb\'ce\'cc\'e5};}{\fhiminor\f31568\fbidi \fswiss\fcharset238\fprq2 Calibri CE;}
-{\fhiminor\f31569\fbidi \fswiss\fcharset204\fprq2 Calibri Cyr;}{\fhiminor\f31571\fbidi \fswiss\fcharset161\fprq2 Calibri Greek;}{\fhiminor\f31572\fbidi \fswiss\fcharset162\fprq2 Calibri Tur;}
-{\fhiminor\f31573\fbidi \fswiss\fcharset177\fprq2 Calibri (Hebrew);}{\fhiminor\f31574\fbidi \fswiss\fcharset178\fprq2 Calibri (Arabic);}{\fhiminor\f31575\fbidi \fswiss\fcharset186\fprq2 Calibri Baltic;}
-{\fhiminor\f31576\fbidi \fswiss\fcharset163\fprq2 Calibri (Vietnamese);}{\fbiminor\f31578\fbidi \froman\fcharset238\fprq2 Times New Roman CE{\*\falt Times New Roman};}
-{\fbiminor\f31579\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr{\*\falt Times New Roman};}{\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek{\*\falt Times New Roman};}
-{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur{\*\falt Times New Roman};}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew){\*\falt Times New Roman};}
-{\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic){\*\falt Times New Roman};}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic{\*\falt Times New Roman};}
-{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese){\*\falt Times New Roman};}}{\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;
-\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;}{\*\defchp 
-\fs21\kerning2\dbch\af17 }{\*\defpap \ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 \snext0 \sqformat \spriority0 Normal;}{
-\s1\qc \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel0\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs36\cf1\lang1033\langfe2052\loch\f13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink15 \sqformat \spriority9 heading 1;}{
-\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\f13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext0 \slink16 \sqformat \spriority9 heading 3;}{\*\cs10 \additive \sunhideused \spriority1 Default Paragraph Font;}{\*
-\ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv 
-\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs21\alang1025 \ltrch\fcs0 \fs21\lang1033\langfe2052\kerning2\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 
-\snext11 \ssemihidden \sunhideused Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs44 \ltrch\fcs0 \b\fs44\kerning44 \sbasedon10 \slink1 \slocked \spriority9 \'b1\'ea\'cc\'e2 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 
-\b\fs32\kerning0 \sbasedon10 \slink3 \slocked \ssemihidden \spriority9 \'b1\'ea\'cc\'e2 3 Char;}{\*\cs17 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \fs18 \sbasedon10 \slink23 \slocked \'d2\'b3\'bd\'c5 Char;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 
-\fs18 \sbasedon10 \slink20 \slocked \sqformat \'d2\'b3\'c3\'bc Char;}{\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\f13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext19 Normal (Web);}{\s20\qc \li0\ri0\widctlpar\brdrb\brdrs\brdrw15\brsp20 
-\tqc\tx4153\tqr\tx8306\wrapdefault\aspalpha\aspnum\faauto\nosnaplinegrid\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs18\lang1033\langfe2052\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 
-\sbasedon0 \snext20 \slink18 \sunhideused header;}{\*\cs21 \additive \rtlch\fcs1 \af0\afs18 \ltrch\fcs0 \fs18\kerning0 \sbasedon10 \ssemihidden \'d2\'b3\'c3\'bc Char1;}{\*\cs22 \additive \rtlch\fcs1 \af0\afs18 \ltrch\fcs0 \fs18\kerning0 
-\sbasedon10 \ssemihidden \'d2\'b3\'c3\'bc Char11;}{\s23\ql \li0\ri0\widctlpar\tqc\tx4153\tqr\tx8306\wrapdefault\aspalpha\aspnum\faauto\nosnaplinegrid\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs18\lang1033\langfe2052\loch\f0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 \sbasedon0 \snext23 \slink17 \sunhideused \sqformat footer;}{\*\cs24 \additive \rtlch\fcs1 \af0\afs18 \ltrch\fcs0 \fs18\kerning0 \sbasedon10 \ssemihidden 
-\'d2\'b3\'bd\'c5 Char1;}{\*\cs25 \additive \rtlch\fcs1 \af0\afs18 \ltrch\fcs0 \fs18\kerning0 \sbasedon10 \ssemihidden \'d2\'b3\'bd\'c5 Char11;}}{\*\rsidtbl \rsid0\rsid726032\rsid6433663\rsid8347566\rsid13768031}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
-\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\author \'ce\'e2\'bd\'ad\'c1\'d6}{\operator \'ce\'ba\'ec\'bf}{\creatim\yr2021\mo1\dy21\hr19\min52}{\revtim\yr2021\mo9\dy28\hr14\min46}{\version3}{\edmins2}
-{\nofpages8}{\nofwords3333}{\nofchars19004}{\nofcharsws22293}{\vern49247}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1800\margr1800\margt1440\margb1440\gutter0\ltrsect 
-\deftab420\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\noxlattoyen
-\expshrtn\noultrlspc\dntblnsbdb\nospaceforul\formshade\horzdoc\dgmargin\dghspace180\dgvspace180\dghorigin1800\dgvorigin1440\dghshow1\dgvshow1
-\jexpand\ksulang2052\viewkind1\viewscale170\splytwnine\ftnlytwnine\htmautsp\nolnhtadjtbl\useltbaln\alntblind\lytcalctblwd\lyttblrtgr\lnbrkrule\nobrkwrptbl\wrppunct\rsidroot726032\nogrowautofit {\*\fchars 
-!),.:\'3b?]\'7d\'a1\'a7\'a1\'a4\'a1\'a6\'a1\'a5\'a8\'44\'a1\'ac\'a1\'af\'a1\'b1\'a1\'ad\'a1\'c3\'a1\'a2\'a1\'a3\'a1\'a8\'a1\'a9\'a1\'b5\'a1\'b7\'a1\'b9\'a1\'bb\'a1\'bf\'a1\'b3\'a1\'bd\'a3\'a1\'a3\'a2\'a3\'a7\'a3\'a9\'a3\'ac\'a3\'ae\'a3\'ba\'a3\'bb\'a3\'bf\'a3\'dd\'a3\'e0\'a3\'fc\'a3\'fd\'a1\'ab\'a1\'e9
-}{\*\lchars ([\'7b\'a1\'a4\'a1\'ae\'a1\'b0\'a1\'b4\'a1\'b6\'a1\'b8\'a1\'ba\'a1\'be\'a1\'b2\'a1\'bc\'a3\'a8\'a3\'ae\'a3\'db\'a3\'fb\'a1\'ea\'a3\'a4}\fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\ftnsep \ltrpar \pard\plain \ltrpar
-\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid13768031 \chftnsep 
-\par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid13768031 \chftnsepc 
-\par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid13768031 \chftnsep 
-\par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid13768031 \chftnsepc 
-\par }}\ltrpar \sectd \ltrsect\linex0\endnhere\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta \dbch .}}{\*\pnseclvl2\pnucltr\pnstart1\pnindent720\pnhang {\pntxta \dbch .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang 
-{\pntxta \dbch .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta \dbch )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}{\*\pnseclvl6\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}
-{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb \dbch (}{\pntxta \dbch )}}
-\pard\plain \ltrpar\s1\qc \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel0\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs36\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 Software Licensing and Terms of Service}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-Important reminder: Please read this Agreement carefully before downloading, installing and using any software or services provided by}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0  C}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 reality}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0  P}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 rint}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 .}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 Your use of the }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 C}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 
-\hich\af0\dbch\af17\loch\f0 reality}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0  P}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 rint}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
- Software Program ("Software") and related Services (collectively referred to as "Services", together with "Equipment" and "Software") provided by the Company after signing this Document will be subject to these Terms of\hich\af0\dbch\af17\loch\f0 
- Use and other legal provisions to which they refer (collectively, the "Agreement"). This Agreement is a binding legal agreement between you and us regarding the use of the Services. Subject to acceptance and compliance with the terms of this Agreement, w
-\hich\af0\dbch\af17\loch\f0 e\hich\af0\dbch\af17\loch\f0  grant you a limited license to use the Services without exclusion. "You" or "User" may be an individual or a single legal entity.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 
-\hich\af0\dbch\af17\loch\f0  }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 1. Acceptance of the Agreement}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 1.1 You may accept this Agreement by: (a) Clicking "Agree" or a similar button}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 (b) Checking t\hich\af0\dbch\af17\loch\f0 he selection box at the end of this Agreement (c) Actually using the Services.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-1.2 You must first accept and agree to this Agreement before using the Services. If you disagree with the terms of this Agreement, please do not download, install, register, or \hich\af0\dbch\af17\loch\f0 
-use the services. If you have paid for and purchased the services, you may contact your supplier for a refund, which must comply with the Company's refund policy.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-1.3 To reach a legally binding agreement, you must be at least 18 years of age, or above 16 y\hich\af0\dbch\af17\loch\f0 
-ears old either with your own independent source of income or with the consent of your parents or legal guardian. If you have not reached the legal age of adulthood for a legally binding contract, you must ensure that this agreement is signed and confirme
-\hich\af0\dbch\af17\loch\f0 d\hich\af0\dbch\af17\loch\f0 
- by your parents or legal guardians on your behalf. If you are accepting this Agreement on behalf of others (e.g. a company or your customer), you declare and guarantee that you have been fully authorized and are qualified to do so.}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 2. Permissions and Rest\hich\af0\dbch\af17\loch\f0 rictions}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-2.1 The Software program used in the Service is under the perpetual ownership of us or our suppliers. The Software is not being sold to an individual, but rather is granting a license for its use. Subject to the terms of this Agreement, you will b
-\hich\af0\dbch\af17\loch\f0 
-e granted a limited and non-exclusive license to use the Software on a single device. You may use the Software only to the extent expressly permitted by this Agreement. You may not: (1) Circumvent any technical limitations in the Software (2) Reverse engi
-\hich\af0\dbch\af17\loch\f0 n\hich\af0\dbch\af17\loch\f0 
-eer, decompile or disassemble the Software (3) Copy, transfer, rent, sell, distribute or otherwise provide the Software to others in any way You may transfer the acquired license, along with the equipment, to a third party on a one-time and permanent basi
-\hich\af0\dbch\af17\loch\f0 s\hich\af0\dbch\af17\loch\f0 
- . Some software or its components may be provided under the open source license that accompanies the Software. With respect to open source software programs only, the terms of the open source license shall preempt and supersede certain terms of this Agre
-\hich\af0\dbch\af17\loch\f0 e\hich\af0\dbch\af17\loch\f0 ment. All other rights not expressly granted are reserved by us or our suppliers. You may not remove or alter any copyrighted or proprietary information related to the Software.}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 2.2 The rights and interests to all content displayed to you through the Servi\hich\af0\dbch\af17\loch\f0 
-ce (including but not limited to videos, audios, texts, pictures, and more) are owned by us or our licensors. You may only use these contents with the Service as they are. You may not modify, rent, lease, sell, publish or distribute the above contents (wh
-\hich\af0\dbch\af17\loch\f0 e\hich\af0\dbch\af17\loch\f0 ther wholly or partially), nor may you compile, alter or create any derivative works of them without our prior written permission.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
+{\rtf1\ansi\ansicpg936\deff0\nouicompat\deflang1033\deflangfe2052\deftab420{\fonttbl{\f0\froman\fprq2\fcharset0 Times New Roman;}{\f1\fnil\fprq2\fcharset134 \'cb\'ce\'cc\'e5;}}
+{\colortbl ;\red0\green0\blue0;\red0\green0\blue255;}
+{\stylesheet{ Normal;}{\s1 heading 1;}}
+{\*\generator Riched20 10.0.19041}{\info{\horzdoc}{\*\lchars ([\'7b\'a1\'a4\'a1\'ae\'a1\'b0\'a1\'b4\'a1\'b6\'a1\'b8\'a1\'ba\'a1\'be\'a1\'b2\'a1\'bc\'a3\'a8\'a3\'ae\'a3\'db\'a3\'fb\'a1\'ea\'a3\'a4}{\*\fchars !),.:\'3b?]\'7d\'a1\'a7\'a1\'a4\'a1\'a6\'a1\'a5\'a8\'44\'a1\'ac\'a1\'af\'a1\'b1\'a1\'ad\'a1\'c3\'a1\'a2\'a1\'a3\'a1\'a8\'a1\'a9\'a1\'b5\'a1\'b7\'a1\'b9\'a1\'bb\'a1\'bf\'a1\'b3\'a1\'bd\'a3\'a1\'a3\'a2\'a3\'a7\'a3\'a9\'a3\'ac\'a3\'ae\'a3\'ba\'a3\'bb\'a3\'bf\'a3\'dd\'a3\'e0\'a3\'fc\'a3\'fd\'a1\'ab\'a1\'e9}}
+{\*\mmathPr\mnaryLim0\mdispDef1\mwrapIndent1440 }\viewkind4\uc1 
+\pard\keep\widctlpar\s1\sb280\sa280\qc\cf1\b\f0\fs36 Software Licensing and Terms of Service\f1\par
 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 2.3 You understand that some content is provided by third parties, that we may not have full control over the content display\hich\af0\dbch\af17\loch\f0 
-ed, that we will not be responsible for content which we have no control over, and that you make your own decisions about whether and how to use such content and bear the risks associated with it. We may, at our own discretion, remove, replace or modify c
-\hich\af0\dbch\af17\loch\f0 e\hich\af0\dbch\af17\loch\f0 
-rtain content at any time to comply with the law or for other purposes. If you notice any infringing or illegal content, you can describe the case in detail in accordance with our copyright policy and notify us. We will coordinate with the content provide
-\hich\af0\dbch\af17\loch\f0 r\hich\af0\dbch\af17\loch\f0  to reach a resolution or have the matter handled according to the law.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 3. Services We Provide}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-3.1 You agree that the Service may be provided by us or the provider entrusted by us.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 3.2 Full use of the Service requires compatible equipment, network access a\hich\af0\dbch\af17\loch\f0 
-nd specific software systems, as well as periodic updates. It may also be affected by the performance of said equipment, network and software. You must consult the instructions on using the Service to verify that your device has the proper hardware and so
-\hich\af0\dbch\af17\loch\f0 f\hich\af0\dbch\af17\loch\f0 
-tware application environment required by the Service. The use of the Service may incur network costs for which you yourself are responsible. These costs are charged at a rate determined by the standards of your network service provider.}{\rtlch\fcs1 
-\af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-3.3 While every ef\hich\af0\dbch\af17\loch\f0 
-fort is made to ensure the accuracy and continuity of the Service, the accuracy, continuity and availability of the Service may occasionally be limited due to individual user differences and differences in hardware, software and network environments outsi
-\hich\af0\dbch\af17\loch\f0 d\hich\af0\dbch\af17\loch\f0 e of the Service. You may improve the accuracy of the Services in accordance with the description of the Service we provide, if any.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 3.4 The Service is available only within the jurisdiction of mainland China. We provide no warranty, support or maintenance\hich\af0\dbch\af17\loch\f0 
- and assume no liability for the use of the Service outside China.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 4. Changes in Service}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-4.1 We may make changes to the Service or any part thereof from time to time for enhancing the customer experience and the continual pursuit of innovation. We may \hich\af0\dbch\af17\loch\f0 
-also change, temporarily suspend, or permanently cancel any feature or component of the Service at any time if the legal or business environment changes and continuing to provide the Service is no longer commercially viable. In addition, to make the most 
-\hich\af0\dbch\af17\loch\f0 o\hich\af0\dbch\af17\loch\f0 
-f available resources, we may cancel individual accounts for which no activity has occurred for more than 60 days. Unless additional terms are provided, the terms of this Agreement apply to all modifications or updates to the Service.}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-4.2 By default, the S\hich\af0\dbch\af17\loch\f0 
-ervice will automatically download and install software updates. You can change the software "settings" at any time and choose to disable automatic updates (not recommended). In certain circumstances (for example, to comply with mandatory legal requiremen
-\hich\af0\dbch\af17\loch\f0 t\hich\af0\dbch\af17\loch\f0 
-s or to improve the reliability and security of the Service), you must make updates to the Service as required. Failure to update may cause disruptions to service availability, corruption or loss of data, system failure, or hardware faults.}{\rtlch\fcs1 
-\af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 4.3 If we cance
-\hich\af0\dbch\af17\loch\f0 
-l the Service in its entirety, you may download your User Data stored in the Service within a reasonable period per notification from us after termination of the Service. Your User Data will be deleted after this initial period of time. If you have paid f
-\hich\af0\dbch\af17\loch\f0 o\hich\af0\dbch\af17\loch\f0 
-r access to the Service, you may request a refund in writing within 30 days of us cancelling the Service. We will refund you on a pro-rata basis according to your actual use of the Service. These are all the methods available to you under this Agreement i
-\hich\af0\dbch\af17\loch\f0 n\hich\af0\dbch\af17\loch\f0  connection with our cancellation of the Service.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 5. Password and Account Security  }{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-5.1 You may need to register an account before using the Service. If the Service allows you to use another account that you have registered, you may use the Service throug\hich\af0\dbch\af17\loch\f0 
-h that account as subject to the terms of this Agreement.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-5.2 During your account registration process and thereafter when requested by us, you agree to provide us with relevant registration information as it is requested. Wherever real name registration i\hich\af0\dbch\af17\loch\f0 
-s required by law, you are to provide us with true, accurate, current and complete account management information and data (such as your name, email address and telephone number, which are collectively referred to as "Registration Information"). You shoul
-\hich\af0\dbch\af17\loch\f0 d\hich\af0\dbch\af17\loch\f0  always maintain and update your registration information in a timely manner. If your registration information is false, incorrect, incomplete or outdated, it may affect your use of the Service.}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 5.3 You shall be fully responsible for all activities carried\hich\af0\dbch\af17\loch\f0 
- out with your account. You agree to: (a) Take all reasonable and feasible measures to properly safeguard your account number and password (including but not limited to setting a password for the account that meets the security standard, and logging out o
-\hich\af0\dbch\af17\loch\f0 f\hich\af0\dbch\af17\loch\f0 
- the account after use) (b) You must immediately notify us of any unauthorized use of your account or any other security issue. We cannot and will not be held liable for any loss or damage arising from the unauthorized use of your account by others. If we
-\hich\af0\dbch\af17\loch\f0  \hich\af0\dbch\af17\loch\f0 
-find that any account has a security issue, we reserve the right to handle it according to our judgment, including but not limited to restricting or prohibiting the use of the account in question until the account is canceled.}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 6. Specifications You Need to\hich\af0\dbch\af17\loch\f0  Comply with
-}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-6.1 You are not to use the Service for any unlawful, fraudulent, improper or abusive purpose. You may not use the Service in any manner that may interfere with the use of the Service by other users, damage any property of ours or other users, 
-\hich\af0\dbch\af17\loch\f0 or violate/prejudice any rights of third parties. You must also comply with all applicable legal requirements.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-6.2 If we, in our sole discretion, have confirmed that your use of the Service: (a) violates any provision of this Agreement (b) is inconsistent \hich\af0\dbch\af17\loch\f0 
-with the User Content Specification (c) is offensive to other users (d) infringes upon our or any third party's intellectual property or other rights or (e) has or may result in any liability to us, we have the right to, without prior notice: (I) suspend 
-\hich\af0\dbch\af17\loch\f0 o\hich\af0\dbch\af17\loch\f0 
-r terminate your use of the Service in part or in whole, or (II) delete your information stored on the Service. In addition, once your account or your access to the Service is terminated, we will delete all content generated by you and other related infor
-\hich\af0\dbch\af17\loch\f0 m\hich\af0\dbch\af17\loch\f0 ation.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-6.3 Care must be taken on your part when using the Service, including having a general understanding on information security for the use of Internet and mobile networks and related devices, such as how to set and protect passwords.}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 6.4 You are solel\hich\af0\dbch\af17\loch\f0 
-y responsible for any loss, damage and other consequences arising from your breach of this Agreement. You agree to indemnify, defend and hold us and our suppliers innocent from and against any losses, costs, liabilities and other expenses arising from you
-\hich\af0\dbch\af17\loch\f0 r\hich\af0\dbch\af17\loch\f0  data, your use of the Service or your breach of the terms of this Agreement.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 7. User Data and Storage}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-7.1 The Service may allow you to upload, store or receive some of your data, which may include contents generated by you and your personal data ("User Da\hich\af0\dbch\af17\loch\f0 
-ta"). Your rights with respect to such User Data are retained by you. Except as otherwise agreed in this Agreement, we will not use your User Data on our own behalf or allow others to use them without your prior consent.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 7.2 You hereby grant us a worldwide\hich\af0\dbch\af17\loch\f0 
-, irrevocable, non-exclusive and free-of-charge license under which we can copy and store your User Data in an encrypted manner and sub-license our Service Provider for the sole purpose of providing and improving the Services. You must ensure that you hav
-\hich\af0\dbch\af17\loch\f0 e\hich\af0\dbch\af17\loch\f0  all the rights and powers required to permit the above items.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-7.3 It is not our obligation to provide storage for your User Data. We only provide this service for the convenience of users. To this end, you know and agree that we will not be responsible fo\hich\af0\dbch\af17\loch\f0 
-r any data deletion or storage failure for any reason. You shall be responsible for consistent and proper backup of your User Data. You know and agree that we may limit the quantity and duration of User Data you upload or store.}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 7.4 The contents you may ge\hich\af0\dbch\af17\loch\f0 
-nerate include but are not limited to the nickname or user name created by you, as well as the voice materials and other contents stored by you. You must ensure that the content you generate does not directly or indirectly contain any of the following: (1
-\hich\af0\dbch\af17\loch\f0 )\hich\af0\dbch\af17\loch\f0 
- Obscenity, disinformation, defamation, libel, blasphemy, indecency and other content that violates public order, morals and local laws and policies (2) Content that violates or abuses the intellectual property rights, reputation, right to reputation, pri
-\hich\af0\dbch\af17\loch\f0 v\hich\af0\dbch\af17\loch\f0 
-acy and other legal rights of third parties (3) Content that impedes national unity and/or promotes violence, national and ethnic division, and ethnic antagonism (4) Content that promotes discrimination or hate speech against certain individuals or groups
-,\hich\af0\dbch\af17\loch\f0 
- whether based on race, gender, nationality, religious beliefs, sexual orientation or the language of such individuals or groups (5) Any advertising and solicitation or promotion of business opportunities (6) Any content that incites, organizes, abets or 
-\hich\af0\dbch\af17\loch\f0 p\hich\af0\dbch\af17\loch\f0 
-romotes illegal activities (7) Any content that is prohibited by law or policy or prohibited under the judgment, ruling, order, notice or direction of a judicial or law enforcement authority having jurisdiction.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 8. Right to privacy}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 Our collection, use, sto\hich\af0\dbch\af17\loch\f0 
-rage and processing of your User Data will be in accordance with our published Privacy Policy. You agree that we can collect, use, store and process your User Data for the purpose of providing and improving this service and for other purposes we have info
-\hich\af0\dbch\af17\loch\f0 r\hich\af0\dbch\af17\loch\f0 
-med you of in advance in accordance with our Privacy Policy. You can find and read our Privacy Policy at the activation point or "Setup" of the device or software for details for collecting, using, storing and processing your personal data. You can also r
-\hich\af0\dbch\af17\loch\f0 e\hich\af0\dbch\af17\loch\f0 ad the online version of the Privacy Policy at our website.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 9. Service Fees}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 
-You may be required to pay additional fees for the use of certain services in accordance with the terms of relevant services. We reserve the right to charge fees for services and r\hich\af0\dbch\af17\loch\f0 
-evise the charging standards and charging methods. Except for transactions by credit card, debit card or electronic payment, the fees shall be due and payable upon receipt of the payment notice. You agree to pay the fees indicated on the payment notice, i
-\hich\af0\dbch\af17\loch\f0 n\hich\af0\dbch\af17\loch\f0 cluding any applicable taxes and late fees. You are solely responsible for paying taxes related to the Service.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 10. Disclaimer of Warranty}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-You understand and agree that the Service is provided on an "as is" and "as available" basis, and to the maximum exte\hich\af0\dbch\af17\loch\f0 
-nt permitted by law unless otherwise expressly stated. We will not make any express or implied guarantee in regards that either the software or Service (including but not limited to implied warranties that relate to merchantability) is suitable for any pa
-\hich\af0\dbch\af17\loch\f0 r\hich\af0\dbch\af17\loch\f0 
-ticular purpose, and is not guilty of any infringement. We do not guarantee that the Service will operate without interruption, in a timely, safe or error-free manner, and that all errors in the Service will be corrected. Unless otherwise stated in writin
-\hich\af0\dbch\af17\loch\f0 g\hich\af0\dbch\af17\loch\f0 , we do not guarantee that we will provide technical support for the Service. The above exclusions also apply to the developers, suppliers and sellers of the Service.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 11. Limitation of Liability}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 In no event shall we be liable to you or third parties for an
-\hich\af0\dbch\af17\loch\f0 
-y special, indirect, incidental, consequential or punitive damages arising out of contract, warranty, tort (including negligence or strict liability) or any other theory of liability, even if we have been informed in advance of the possibility of such dam
-\hich\af0\dbch\af17\loch\f0 a\hich\af0\dbch\af17\loch\f0 ge or if the occurrence of such damage can be reasonably foreseen by us. Our entire liability for any and}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 
- all damages will be limited to}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0  the total amount we have charged you for the Service provided 1 month prior to the date the event causing litigation or
-\hich\af0\dbch\af17\loch\f0  c}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 laim first occurred, or}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
- 100 dollars; whichever is greater. The limitation of liability herein reflects the allocation of risk expressly agreed to by the parties to this Agreement. The limitations set forth in this clause will apply in any and all circums
-\hich\af0\dbch\af17\loch\f0 
-tances, including the developers, suppliers and sellers of the Service, and shall extend beyond the termination of this Agreement. The laws of some jurisdictions do not allow certain limitations of liability. In such cases, these limitations will not appl
-\hich\af0\dbch\af17\loch\f0 y\hich\af0\dbch\af17\loch\f0  to you.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 12. Consumer Rights}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-Nothing in this Agreement shall affect any legal rights of consumers that cannot be waived or limited by contract. You may also have other rights that cannot be altered by this Agreement under relevant legal provisions.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 13. Thi\hich\af0\dbch\af17\loch\f0 rd-party Software and Services}{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-You understand that certain functions or components of the Service may be provided by third parties. The service user's interface may provide links to third-parties' websites. Clicking these links will grant access to third-party websites that are not ope
-\hich\af0\dbch\af17\loch\f0 r\hich\af0\dbch\af17\loch\f0 
-ated, managed and supported by us. Third-party software or services will be provided based on their independent license agreements, service terms and privacy policies, which may differ from our provisions. Any of your personal information submitted or col
-\hich\af0\dbch\af17\loch\f0 l\hich\af0\dbch\af17\loch\f0 
-ected by you through third party software or services is not applicable under our privacy policy. If you choose to use third-party software or services, please read the relevant legal provisions of the third party carefully. Unless expressly stated otherw
-\hich\af0\dbch\af17\loch\f0 i\hich\af0\dbch\af17\loch\f0 
-se, we do not make any representations and warranties of third party software or services and their contents, including but not limited to their availability and continuity. Third parties may provide their own guarantees for their software or services. }{
-\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 You\hich\af0\dbch\af17\loch\f0 
- understand and agree that you will use this third party software or services and their contents based of your own volition and at your own risk.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 14. Marketing Materials and Promotion Services}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 We may send you some marketing materials and offer you addition
-\hich\af0\dbch\af17\loch\f0 
-al promotion services from time to time, for which you will not be charged incur any additional charges ("Promotion Services"). You know and agree that we can send you the above marketing and promotion materials via electronic transmission, email, traditi
-\hich\af0\dbch\af17\loch\f0 o\hich\af0\dbch\af17\loch\f0 
-nal mail or other means. You may suspend the sending of these materials at any time. You understand and agree that we may adjust the scope of the above-mentioned promotion services at any time without further notice, that some promotion services may be of
-\hich\af0\dbch\af17\loch\f0 f\hich\af0\dbch\af17\loch\f0 
-ered for new customers, and that you may not be able to obtain some or all of the above promotion services. If you have obtained any promotion or special prices or conditions provided by us, these prices or conditions apply only to you and you are to keep
-\hich\af0\dbch\af17\loch\f0  \hich\af0\dbch\af17\loch\f0 them in the strictest confidence.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-You may not disclose such information to any third party without our prior express written consent.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 15. Revision and Termination of the Agreement}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-15.1 We may change the terms of this Agreement at any time. Notifications ma\hich\af0\dbch\af17\loch\f0 
-y be made for these modifications through our website, client announcements or other channels. You agree that if you continue to use the Service upon notification of such changes, you will accept the modified agreement.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 15.2 You can terminate this Agreemen\hich\af0\dbch\af17\loch\f0 
-t at any time by deleting the software, closing your account and discontinue using the service, according to relevant instructions. This Agreement terminates upon our cancellation of all services as agreed in this Agreement. Neither party shall be liable 
-\hich\af0\dbch\af17\loch\f0 f\hich\af0\dbch\af17\loch\f0 or the termination.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-15.3 If we discover you are using the Service for any purpose that is unauthorized or prohibited by this Agreement, or if your conduct is such that we have reason to believe that continuing to provide the Service to you may pose a great
-\hich\af0\dbch\af17\loch\f0 er risk to us, we may, at our discretion, terminate this Agreement and make a claim against you for fees for use of the Service and for damages resulting from your misuse.}{\rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 15.4 You agree that upon termination of this Agreement, you will destroy the Softwar\hich\af0\dbch\af17\loch\f0 
-e and permanently delete any and all backups. Your right to use the Service will be subject to immediate termination.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 15.5 Clauses in this Agreement entitled "Permissions and Restrictions", "Disclaimer of Warranty", "Limitation of Liability" and "General P
-\hich\af0\dbch\af17\loch\f0 rovisions" and other terms that by their nature remain in effect at all times shall extend beyond the termination of this Agreement.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s3\ql \li0\ri0\sb280\sa280\keep\widctlpar\wrapdefault\aspalpha\aspnum\faauto\outlinelevel2\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\b\fs26\cf1\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 16. General Provisions}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }\pard\plain \ltrpar\s19\qj \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe2052\loch\af13\hich\af13\dbch\af17\cgrid\langnp1033\langfenp2052 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-16.1 This Agreement shall be governed by and construed in accordance with applicable laws of the ju\hich\af0\dbch\af17\loch\f0 
-risdictions of mainland China (for clarity, excluding the Hong Kong Special Administrative Region, the Macau Special Administrative Region and Taiwan). Any dispute arising out of or in connection with this Agreement shall first be settled by amicable nego
-\hich\af0\dbch\af17\loch\f0 t\hich\af0\dbch\af17\loch\f0 iation. If such negotiations fail, the dispute shall be subject to the exclusive jurisdiction of the court in our place.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663 \hich\af0\dbch\af17\loch\f0 16.2 This Agreement, in conjunction with the Privacy Policy and other special terms referenced, constitutes the entire agreement betwee\hich\af0\dbch\af17\loch\f0 
-n you and us with respect to the Service and supersedes all other communications or exchanges, whether in oral or written form. Unless otherwise agreed in this Agreement, any modification to this Agreement shall be made in the form of a written supplement
-\hich\af0\dbch\af17\loch\f0 a\hich\af0\dbch\af17\loch\f0 
-ry agreement. Our failure to exercise or enforce any right or term contained in this Agreement shall not be deemed a waiver of any relevant rights or provisions. If any provision or part of this Agreement is determined by a competent tribunal to be unenfo
-\hich\af0\dbch\af17\loch\f0 r\hich\af0\dbch\af17\loch\f0 ceable, it shall not affect the validity of other parts of this Agreement, and other parts of this Agreement shall remain in force.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 16.3 You agree that we may send notices to you for the purposes of this Agreement by email, cell phone text message, message\hich\af0\dbch\af17\loch\f0 
- pop-up or other mail transmission methods. You agree that all notices to users under this Agreement may also be given by means of web announcements. Such notices shall be deemed to have been delivered to the recipient on the date of delivery. Notices sen
-\hich\af0\dbch\af17\loch\f0 t\hich\af0\dbch\af17\loch\f0  by you to us shall be delivered to us at our officially published mailing address, e-mail address, etc.}{\rtlch\fcs1 \af0 \ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }\pard \ltrpar\s19\ql \li0\ri0\sb100\sa100\sbauto1\saauto1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 {\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\cf1\insrsid6433663\charrsid10364218 \hich\af0\dbch\af17\loch\f0 
-If you have any questions, comments or suggestions regarding the contents of this Agreement, you may contact us by e-mail at: }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6433663 \hich\af13\dbch\af17\loch\f13 crealityprint@creality.com}{\rtlch\fcs1 \af0 
-\ltrch\fcs0 \cf1\insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid1125977 \hich\af0\dbch\af17\loch\f0 Sh\hich\af0\dbch\af17\loch\f0 enzhen\hich\af0\dbch\af17\loch\f0  Creality 3D T}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid1125977 
-\hich\af0\dbch\af17\loch\f0 echno}{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid1125977 \hich\af0\dbch\af17\loch\f0 logy Co.,Ltd}{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid6433663\charrsid6433663 
-\par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \f0\insrsid6433663\charrsid1125977 \hich\af0\dbch\af17\loch\f0 18F,JinXiuHongDu Building,Meilong Blvd.,Longhua Dist.,Shenzhen,China
-\par }\pard\plain \ltrpar\ql \li0\ri0\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0\pararsid6433663 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe2052\loch\af0\hich\af0\dbch\af17\cgrid\langnp1033\langfenp2052 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid8347566\charrsid6433663 
-\par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
-9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
-5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
-b01d583deee5f99824e290b4ba3f364eac4a430883b3c092d4eca8f946c916422ecab927f52ea42b89a1cd59c254f919b0e85e6535d135a8de20f20b8c12c3b0
-0c895fcf6720192de6bf3b9e89ecdbd6596cbcdd8eb28e7c365ecc4ec1ff1460f53fe813d3cc7f5b7f020000ffff0300504b030414000600080000002100a5d6
-a7e7c0000000360100000b0000005f72656c732f2e72656c73848fcf6ac3300c87ef85bd83d17d51d2c31825762fa590432fa37d00e1287f68221bdb1bebdb4f
-c7060abb0884a4eff7a93dfeae8bf9e194e720169aaa06c3e2433fcb68e1763dbf7f82c985a4a725085b787086a37bdbb55fbc50d1a33ccd311ba548b6309512
-0f88d94fbc52ae4264d1c910d24a45db3462247fa791715fd71f989e19e0364cd3f51652d73760ae8fa8c9ffb3c330cc9e4fc17faf2ce545046e37944c69e462
-a1a82fe353bd90a865aad41ed0b5b8f9d6fd010000ffff0300504b0304140006000800000021006b799616830000008a0000001c0000007468656d652f746865
-6d652f7468656d654d616e616765722e786d6c0ccc4d0ac3201040e17da17790d93763bb284562b2cbaebbf600439c1a41c7a0d29fdbd7e5e38337cedf14d59b
-4b0d592c9c070d8a65cd2e88b7f07c2ca71ba8da481cc52c6ce1c715e6e97818c9b48d13df49c873517d23d59085adb5dd20d6b52bd521ef2cdd5eb9246a3d8b
-4757e8d3f729e245eb2b260a0238fd010000ffff0300504b030414000600080000002100e96c4e8db4060000ab1b0000160000007468656d652f7468656d652f
-7468656d65312e786d6cec594f6f134714bf57ea7718ed1d62277688231c143b36692110c5868ae3783dde1d32bbb39a1927f886e08854a92aad3814a9eaa587
-aa2d1248ad54fa651a4a45a9c457e89b99ddf54ebc6e1288286a891089677ff3febfdfbc599fbf702b62688f084979dcf4aa672b1e22b1cf87340e9adeb57ef7
-cc8a87a4c2f110331e93a63721d2bbb0f6e107e7f1aa0a494410ec8fe52a6e7aa152c9eac282f46119cbb33c21313c1b711161051f45b03014781fe4466c61b1
-52595e88308d3d14e308c45e1d8da84fd0b39f7f79f1cd83df6edf837fde5aa6a3c34051aca45ef099e8690dc4d968b0c3ddaa46c8896c3381f6306b7aa06ec8
-f7fbe496f210c352c183a657313fdec2daf905bc9a6e626acedec2beaef949f7a51b86bb8b46a70806b9d26ab7d638b791cb3700a666719d4ea7dda9e6f20c00
-fb3e786a6d29caac7557aaad4c660164ff9c95ddaed42b35175f90bf346373a3d56ad51ba92d56a801d93f6b33f895ca726d7dd1c11b90c5d767f0b5d67abbbd
-ece00dc8e29767f0dd738de59a8b37a090d1787706ad13daeda6d273c888b3cd52f80ac0572a297c8a826ac8ab4bab18f158cdabb508dfe4a20b000d6458d118
-a9494246d887626ee3682028d60af02ac1852776c997334b5a1792bea0896a7a1f27181a632aefd5d3ef5f3d7d8c0eee3c39b8f3d3c1ddbb07777eb4829c5d9b
-380e8abb5e7efbd95f0f6fa33f1f7ffdf2fe17e57859c4fffec3bd67bf7e5e0e84f6999af3fccb477f3c79f4fcc1a72fbebb5f025f17785084f7694424ba42f6
-d10e8fc0311315d772321027dbd10f312dee588f038963acb594c8efa8d0415f99609666c7b1a345dc085e17401f65c08be39b8ec1bd508c152dd17c298c1ce0
-16e7acc54569142e695d8530f7c77150ae5c8c8bb81d8cf7ca74b771ece4b7334e8037b3b2741c6f87c431739be158e180c44421fd8cef1252e2dd0d4a9db86e
-515f70c9470adda0a885696948fa74e054d374d3268d202f93329f21df4e6cb6aea31667655e6f903d17095d815989f17dc29c305ec46385a332917d1cb162c0
-2f63159619d99b08bf88eb4805990e08e3a833245296edb92ac0df42d22f6160acd2b46fb149e42285a2bb65322f63ce8bc80dbedb0e719494617b340e8bd88f
-e42e942846db5c95c1b7b8db21fa33e401c773d37d9d1227dd47b3c1351a38264d0b443f198b925c5e24dca9dfde848d30315403a4ee707544e37f226e4681b9
-ad86d3236ea0cae75f3d2cb1fb5da5ec7538bdca7a66f31051cfc31da6e7361743faeeb3f3061ec7db041a62f6887a4fceefc9d9fbcf93f3bc7e3e7d4a9eb230
-10b49e45eca06dc6ee68eed43da28cf5d48491cbd20cde12ce9e611716f53e73f124f92d2c09e14fddc9a0c0c105029b3d4870f50955612fc4090ced554f0b09
-642a3a9028e1122e8b66b954b6c6c3e0afec55b3ae2f21963924565b7c689797f47276d7c8c518ab0273a1cd142d6901c755b6742e150abebd8eb2aa36ead8da
-aac634438a8eb6dc651d6273298790e7aec1621e4d186a108c4210e565b8fa6bd570d9c18c0c75dc6d8eb2b4982c9c668a64888724cd91f67b36475593a4ac56
-661cd17ed862d017c723a256d0d6d062df40db71925454579ba32ecbde9b6429abe0699640dae1766471b139598cf69b5ea3be58f7908f93a637827b32fc1925
-9075a9e748cc0278e7e42b61cbfec866365d3ecd662373cc6d822abcfab0719f71d8e1814448b58165684bc33c4a4b80c55a93b57fb10e613d2d074ad8e87856
-2cad4031fc6b56401cddd492d188f8aa98ecc28a8e9dfd9852291f2b227ae1701f0dd858ec6048bf2e55f0674825bcee308ca03fc0bb391d6df3c825e7b4e98a
-6fc40cceae63968438a55bdda259275bb821a4dc06f3a9601ef8566abb71eee4ae98963f25578a65fc3f73459f27f0f66169a833e0c31b628191ee94a6c7850a
-39b0501252bf2b607030dc01d502ef77e1311415bca736bf05d9d3bf6dcf5919a6ade112a97668800485f3488582906da025537d4708aba6679715c95241a6a2
-0ae6cac49a3d207b84f535072eebb3dd432194ba619394060cee70fdb99fd30e1a047ac829f69bc364f9d96b7be06d4f3eb699c1299787cd4093c53f37311f0f
-a6a7aadd6fb667676fd111fd603a66d5b2ae006585a3a091b6fd6b9a70c2a3d632d68cc78bf5cc38c8e2acc7b0980f4409bc4342fa3f38ffa8f0193165ac0fd4
-3edf016e45f0e58516066503557dc60e1e4813a45d1cc0e064176d31695136b4e9e8a4a3961dd6a73ce9e67a0f055b5b769c7c9f30d8f970e6aa737af134839d
-46d889b55d9b1b6ac8ece11685a5517691318931df9615bfc9e2839b90e80df8ce60cc9434c504df53090c3374cff40134bfd568b6aefd0d0000ffff0300504b
-0304140006000800000021000dd1909fb60000001b010000270000007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72
-656c73848f4d0ac2301484f78277086f6fd3ba109126dd88d0add40384e4350d363f2451eced0dae2c082e8761be9969bb979dc9136332de3168aa1a083ae995
-719ac16db8ec8e4052164e89d93b64b060828e6f37ed1567914b284d262452282e3198720e274a939cd08a54f980ae38a38f56e422a3a641c8bbd048f7757da0
-f19b017cc524bd62107bd5001996509affb3fd381a89672f1f165dfe514173d9850528a2c6cce0239baa4c04ca5bbabac4df000000ffff0300504b01022d0014
-000600080000002100e9de0fbfff0000001c0200001300000000000000000000000000000000005b436f6e74656e745f54797065735d2e786d6c504b01022d00
-14000600080000002100a5d6a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c73504b01022d0014000600080000
-0021006b799616830000008a0000001c00000000000000000000000000190200007468656d652f7468656d652f7468656d654d616e616765722e786d6c504b01
-022d0014000600080000002100e96c4e8db4060000ab1b00001600000000000000000000000000d60200007468656d652f7468656d652f7468656d65312e786d
-6c504b01022d00140006000800000021000dd1909fb60000001b0100002700000000000000000000000000be0900007468656d652f7468656d652f5f72656c732f7468656d654d616e616765722e786d6c2e72656c73504b050600000000050005005d010000b90a00000000}
-{\*\colorschememapping 3c3f786d6c2076657273696f6e3d22312e302220656e636f64696e673d225554462d3822207374616e64616c6f6e653d22796573223f3e0d0a3c613a636c724d
-617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
-6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
-656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax267\lsdlockeddef0\lsdsemihiddendef1\lsdunhideuseddef1\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 1;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 2;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;
-\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;
-\lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdpriority39 \lsdlocked0 toc 1;\lsdpriority39 \lsdlocked0 toc 2;\lsdpriority39 \lsdlocked0 toc 3;\lsdpriority39 \lsdlocked0 toc 4;\lsdpriority39 \lsdlocked0 toc 5;\lsdpriority39 \lsdlocked0 toc 6;
-\lsdpriority39 \lsdlocked0 toc 7;\lsdpriority39 \lsdlocked0 toc 8;\lsdpriority39 \lsdlocked0 toc 9;\lsdsemihidden0 \lsdlocked0 header;\lsdsemihidden0 \lsdqformat1 \lsdlocked0 footer;\lsdqformat1 \lsdpriority35 \lsdlocked0 caption;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority10 \lsdlocked0 Title;\lsdpriority1 \lsdlocked0 Default Paragraph Font;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority11 \lsdlocked0 Subtitle;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority22 \lsdlocked0 Strong;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority20 \lsdlocked0 Emphasis;\lsdsemihidden0 \lsdunhideused0 \lsdlocked0 Normal (Web);
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority59 \lsdlocked0 Table Grid;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 No Spacing;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 List Paragraph;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 Quote;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdlocked0 Intense Quote;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 1;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 1;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 2;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 2;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 3;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 3;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 4;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 4;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 5;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 5;\lsdsemihidden0 \lsdunhideused0 \lsdpriority60 \lsdlocked0 Light Shading Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority61 \lsdlocked0 Light List Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority62 \lsdlocked0 Light Grid Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority63 \lsdlocked0 Medium Shading 1 Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority64 \lsdlocked0 Medium Shading 2 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority65 \lsdlocked0 Medium List 1 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority66 \lsdlocked0 Medium List 2 Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority67 \lsdlocked0 Medium Grid 1 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority68 \lsdlocked0 Medium Grid 2 Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority69 \lsdlocked0 Medium Grid 3 Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority70 \lsdlocked0 Dark List Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority71 \lsdlocked0 Colorful Shading Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdpriority72 \lsdlocked0 Colorful List Accent 6;
-\lsdsemihidden0 \lsdunhideused0 \lsdpriority73 \lsdlocked0 Colorful Grid Accent 6;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority19 \lsdlocked0 Subtle Emphasis;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority21 \lsdlocked0 Intense Emphasis;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority31 \lsdlocked0 Subtle Reference;
-\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority32 \lsdlocked0 Intense Reference;\lsdsemihidden0 \lsdunhideused0 \lsdqformat1 \lsdpriority33 \lsdlocked0 Book Title;\lsdpriority37 \lsdlocked0 Bibliography;
-\lsdqformat1 \lsdpriority39 \lsdlocked0 TOC Heading;}}{\*\datastore 0105000002000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
-d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000d084
-b18234b4d701feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
-00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
-000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
-0000000000000000000000000000000000000000000000000105000000000000}}
+\pard\widctlpar\sb100\sa100\b0\f0\fs24 Important reminder: Please read this Agreement carefully before downloading, installing and using any software or services provided by Creality Print.\f1\par
+\f0 GNU AFFERO GENERAL PUBLIC LICENSE\par
+Version 3, 19 November 2007\par
+\par
+Copyright \'a9 2007 Free Software Foundation, Inc. <{{\field{\*\fldinst{HYPERLINK "https://fsf.org/"}}{\fldrslt{https://fsf.org/\ul0\cf0}}}}\f0\fs24 >\par
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.\par
+\par
+Preamble\par
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.\par
+\par
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.\par
+\par
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.\par
+\par
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.\par
+\par
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate. Many developers of free software are heartened and encouraged by the resulting cooperation. However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.\par
+\par
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community. It requires the operator of a network server to provide the source code of the modified version running there to the users of that server. Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.\par
+\par
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals. This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.\par
+\par
+The precise terms and conditions for copying, distribution and modification follow.\par
+\par
+TERMS AND CONDITIONS\par
+0. Definitions.\par
+"This License" refers to version 3 of the GNU Affero General Public License.\par
+\par
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.\par
+\par
+"The Program" refers to any copyrightable work licensed under this License. Each licensee is addressed as "you". "Licensees" and "recipients" may be individuals or organizations.\par
+\par
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.\par
+\par
+A "covered work" means either the unmodified Program or a work based on the Program.\par
+\par
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.\par
+\par
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.\par
+\par
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.\par
+\par
+1. Source Code.\par
+The "source code" for a work means the preferred form of the work for making modifications to it. "Object code" means any non-source form of a work.\par
+\par
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.\par
+\par
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.\par
+\par
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.\par
+\par
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.\par
+\par
+The Corresponding Source for a work in source code form is that same work.\par
+\par
+2. Basic Permissions.\par
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.\par
+\par
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.\par
+\par
+Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.\par
+\par
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.\par
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.\par
+\par
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.\par
+\par
+4. Conveying Verbatim Copies.\par
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.\par
+\par
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.\par
+\par
+5. Conveying Modified Source Versions.\par
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:\par
+\par
+a) The work must carry prominent notices stating that you modified it, and giving a relevant date.\par
+b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to "keep intact all notices".\par
+c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.\par
+d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.\par
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.\par
+\par
+6. Conveying Non-Source Forms.\par
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:\par
+\par
+a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.\par
+b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.\par
+c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.\par
+d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.\par
+e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.\par
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.\par
+\par
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.\par
+\par
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.\par
+\par
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).\par
+\par
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.\par
+\par
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.\par
+\par
+7. Additional Terms.\par
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.\par
+\par
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.\par
+\par
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:\par
+\par
+a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or\par
+b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or\par
+c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or\par
+d) Limiting the use for publicity purposes of names of licensors or authors of the material; or\par
+e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or\par
+f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.\par
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.\par
+\par
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.\par
+\par
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.\par
+\par
+8. Termination.\par
+You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).\par
+\par
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.\par
+\par
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.\par
+\par
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.\par
+\par
+9. Acceptance Not Required for Having Copies.\par
+You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.\par
+\par
+10. Automatic Licensing of Downstream Recipients.\par
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.\par
+\par
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.\par
+\par
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.\par
+\par
+11. Patents.\par
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's "contributor version".\par
+\par
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.\par
+\par
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.\par
+\par
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.\par
+\par
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.\par
+\par
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.\par
+\par
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.\par
+\par
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.\par
+\par
+12. No Surrender of Others' Freedom.\par
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.\par
+\par
+13. Remote Network Interaction; Use with the GNU General Public License.\par
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software. This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.\par
+\par
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.\par
+\par
+14. Revised Versions of this License.\par
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.\par
+\par
+Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.\par
+\par
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.\par
+\par
+Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.\par
+\par
+15. Disclaimer of Warranty.\par
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\par
+\par
+16. Limitation of Liability.\par
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.\par
+\par
+17. Interpretation of Sections 15 and 16.\par
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.\par
+\par
+END OF TERMS AND CONDITIONS\par
+\par
+How to Apply These Terms to Your New Programs\par
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.\par
+\par
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.\par
+\par
+    <one line to give the program's name and a brief idea of what it does.>\par
+    Copyright (C) <year>  <name of author>\par
+\par
+    This program is free software: you can redistribute it and/or modify\par
+    it under the terms of the GNU Affero General Public License as\par
+    published by the Free Software Foundation, either version 3 of the\par
+    License, or (at your option) any later version.\par
+\par
+    This program is distributed in the hope that it will be useful,\par
+    but WITHOUT ANY WARRANTY; without even the implied warranty of\par
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\par
+    GNU Affero General Public License for more details.\par
+\par
+    You should have received a copy of the GNU Affero General Public License\par
+    along with this program.  If not, see <{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f0\fs24 >.\par
+Also add information on how to contact you by electronic and paper mail.\par
+\par
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source. For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code. There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.\par
+\par
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <{{\field{\*\fldinst{HYPERLINK "https://www.gnu.org/licenses/"}}{\fldrslt{https://www.gnu.org/licenses/\ul0\cf0}}}}\f0\fs24 >.\par
+}
+ 


### PR DESCRIPTION
Slic3r, PrusaSlicer, and OrcaSlicer are AGPL licensed. 

You _cannot_ unilaterally change the license for those projects without consent of those projects. This means that if you want to redistribute the projects, you are **required** to do so under the AGPL as well. Creality has added a illegitimate much more restrictive license file that is something users are required to agree to as part of the installer. 

**Creality cannot do this**.

In any event, this PR just fixes the base issue by just replacing the specious license from creality with the AGPL, as is required. I'm sure there are some desires by creality to have further restrictions on their web services stuff, but I'm not interested in spending my free time to act as a free lawyer for creality to help them figure out how to bring their web service terms into alignment with the AGPL. 