### PR TITLE
use gnome sdk 49

### DIFF
--- a/flatpak/io.github.crealityofficial.CrealityPrint.yml
+++ b/flatpak/io.github.crealityofficial.CrealityPrint.yml
@@ -1,6 +1,6 @@
 app-id: io.github.crealityofficial.CrealityPrint
 runtime: org.gnome.Platform
-runtime-version: "47"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 command: entrypoint
 separate-locales: true


### PR DESCRIPTION
# Description

use the current gnome sdk, version 47 is unsupported