### PR TITLE
Fix: Post-processing scripts do not run on "Send Print"

### DIFF
--- a/src/slic3r/GUI/print_manage/App/SendToPrinter.cpp
+++ b/src/slic3r/GUI/print_manage/App/SendToPrinter.cpp
@@ -28,6 +28,7 @@
 #include "slic3r/GUI/PartPlate.hpp"
 #include "slic3r/GUI/AnalyticsDataUploadManager.hpp"
 #include "libslic3r/Print.hpp"
+#include "libslic3r/GCode/PostProcessor.hpp"
 #include <wx/variant.h>
 #include <wx/datstrm.h>
 #include "../data/DataCenter.hpp"
@@ -915,6 +916,20 @@ void CxSentToPrinterDialog::handle_send_gcode(const nlohmann::json& json_data)
         }
         else{
             gcodeFilePath = _L(plate->get_tmp_gcode_path()).ToUTF8();
+        }
+
+		// Run post-processing scripts before sending to printer
+        if (!m_plater->only_gcode_mode()) {
+            try {
+                Slic3r::Print* print = nullptr;
+                plate->get_print((Slic3r::PrintBase**)&print, nullptr, nullptr);
+                if (print) {
+                    std::string output_name = gcodeFilePath;
+                    run_post_process_scripts(gcodeFilePath, false, "File", output_name, print->full_print_config());
+                }
+            } catch (const std::exception& e) {
+                BOOST_LOG_TRIVIAL(error) << "Post-processing script failed when sending to printer: " << e.what();
+            }
         }
         
         m_uploadingIp = ipAddress;


### PR DESCRIPTION
### Problem
Post-processing scripts were executed correctly when exporting gcode files after slicing, but were not executed when sending gcode directly to the printer. 

### Root Cause
In `BackgroundSlicingProcess.cpp`, the `finalize_gcode()` function calls `run_post_process_scripts()` to execute post-processing scripts when exporting G-code. However, in `SendToPrinter.cpp`, the `handle_send_gcode()` function directly used the temporary G-code file path to send to the printer, bypassing the post-processing step entirely.

### Solution
- Added `libslic3r/GCode/PostProcessor.hpp` header include in `SendToPrinter.cpp`
- Added `run_post_process_scripts()` call in `handle_send_gcode()` function after obtaining the gcode file path and before uploading
- Post-processing is only executed in non-gcode-only mode (consistent with export logic)
- Added exception handling to ensure post-processing failures don't block the send workflow

### Files Changed
- `src/slic3r/GUI/print_manage/App/SendToPrinter.cpp`

---
This should fix issue #449.
