### PR TITLE
thumbnail format should be cr_png

### DIFF
--- a/resources/profiles/Creality/machine/Creality K1 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K1 0.4 nozzle.json
@@ -79,7 +79,7 @@
     "support_chamber_temp_control": "0",
     "support_multi_bed_types": "1",
     "thumbnails": "96x96,300x300",
-    "thumbnails_format": "PNG",
+    "thumbnails_format": "CR_PNG",
     "time_cost": "0",
     "use_firmware_retraction": "0",
     "use_relative_e_distances": "1",


### PR DESCRIPTION
# Description

k1 gcode did not include a png thumbnail to display on the machine interface

# Screenshots/Recordings/Graphs

## Tests

Once gcode is exported to USB with  CR_PNG format thumbnails it displays on the interface. Other printer profiles may also benefit from this too - this is the only one I have physical access to.