### PR TITLE
Implement macOS cold start fix in GUI_App to store URL for post-initi…

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -10317,6 +10317,18 @@ void GUI_App::MacOpenURL(const wxString& url)
 {
     if (url.empty())
         return;
+    
+    // Fix for macOS cold start: If not yet post-initialized, store the URL in 
+    // init_params->input_files so that post_init() will detect it and set 
+    // switch_to_3d = true. This prevents trigger_restore_project() from calling 
+    // new_project() which would clear the model that will be loaded from this URL.
+    // This makes macOS behavior consistent with Windows.
+    if (!m_post_initialized) {
+        BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ": cold start detected, storing URL to init_params: " << url.ToStdString();
+        this->init_params->input_files.emplace_back(into_u8(url));
+        return;  // post_init() will call start_download() for us
+    }
+    
     start_download(boost::nowide::narrow(url));
 }
 


### PR DESCRIPTION
…alization handling, ensuring consistent behavior with Windows.
This pull request addresses an issue with opening URLs on macOS during a cold start in the `GUI_App` class. The update ensures that URLs opened before the application is fully initialized are handled consistently with Windows, preventing the model from being cleared unintentionally.

macOS cold start handling improvements:

* Modified `GUI_App::MacOpenURL` in `src/slic3r/GUI/GUI_App.cpp` to store the URL in `init_params->input_files` if the application is not yet post-initialized, ensuring the model is not cleared and the URL is properly processed after initialization. This aligns macOS behavior with Windows and prevents loss of the model to be loaded from the URL.