### PR TITLE
Support for previously defined LD_LIBRARY_PATH in AppImage runner

### DIFF
--- a/src/platform/unix/BuildLinuxImage.sh.in
+++ b/src/platform/unix/BuildLinuxImage.sh.in
@@ -38,6 +38,12 @@ echo -n "[9/9] Generating Linux app..."
 cat << EOF >@SLIC3R_APP_CMD@
 #!/bin/bash
 DIR=\$(readlink -f "\$0" | xargs dirname)
+
+# Support for previously defined LD_LIBRARY_PATH.
+EXT_LIB_PATH=""
+if [ "x\$LD_LIBRARY_PATH" != "x" ]; then
+	EXT_LIB_PATH=":\$LD_LIBRARY_PATH"
+fi
 export LD_LIBRARY_PATH="\$DIR/bin:\$DIR/usr/lib"
 
 # FIXME: CrealityPrint segfault workarounds


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

The launcher (AppRun script) of the Linux AppImage was ignoring the existence of the pre-defined environment variable LD_LIBRARY_PATH. For example, on Fedora 43, the library libbz2.so.1.0 is not available, resulting in the error "error while loading shared libraries: libbz2.so.1.0: cannot open shared object file: No such file or directory", which can be easily fixed by creating a link to the library and setting the LD_LIBRARY_PATH variable. However, the AppImage is overwriting the variable.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

https://github.com/user-attachments/assets/0020906e-ae7a-4576-b78d-c46afbc2d128

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

The effectiveness has already been demonstrated in the video above.