### PR TITLE
Fix Linux segfault on application exit (dead GL context in global destructors)

### DIFF
--- a/src/CrealityPrint.cpp
+++ b/src/CrealityPrint.cpp
@@ -6709,6 +6709,11 @@ extern "C" {
 #ifdef USE_BREAKPAD
 static bool dumpCallback(const google_breakpad::MinidumpDescriptor& descriptor,void* context, bool succeeded) {
                 printf("Dump path: %s\n", descriptor.path());
+		 // This runs from breakpad's signal handler. A C++ exception escaping here
+		 // (e.g. boost::filesystem::rename throwing when the target dir is missing)
+		 // unwinds out of the signal handler and double-faults into a second, harder
+		 // crash. Keep every throwing operation below inside this guard.
+		 try {
 		 if (succeeded) {
 		     boost::filesystem::path oldPath(descriptor.path());
 		     std::string data_dir = Slic3r::data_dir();
@@ -6762,6 +6767,9 @@ static bool dumpCallback(const google_breakpad::MinidumpDescriptor& descriptor,v
 		     BOOST_LOG_TRIVIAL(info) << "MiniDump succeeded: " << descriptor.path();
 		 } else {
 		     BOOST_LOG_TRIVIAL(error) << "MiniDump failed: " << descriptor.path();
+		 }
+		 } catch (...) {
+		     // Never let an exception escape the signal handler.
 		 }
                 return succeeded;
             }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3832,7 +3832,18 @@ int GUI_App::OnExit()
     int result = wxApp::OnExit();
     BOOST_LOG_TRIVIAL(warning) << __FUNCTION__ << " end";
     boost::log::core::get()->flush();
+#ifdef __linux__
+    // On Linux the GL/GTK context is already torn down by the time std::exit() drives
+    // the global/static destructors. Static GLModel instances then call
+    // GLModel::RenderData::release() -> glDeleteBuffers() into a dead context, which
+    // segfaults on shutdown (and breakpad's handler double-faults on top of it).
+    // All persistent state (AppConfig, presets) has already been saved during the
+    // window-close sequence and wxApp::OnExit() above, so skip the global-destructor
+    // teardown entirely and terminate immediately.
+    std::_Exit(0);
+#else
     std::exit(0);
+#endif
     return 0;
 }
 


### PR DESCRIPTION
## Problem

On Linux, Creality Print segfaults on **every** exit (reproducible across 7.0.x → 7.2.0). systemd records a `SIGSEGV` coredump each time the app is closed.

The `coredumpctl` traces are truncated (the unwinder itself crashes), and a stray `libjavascriptcoregtk` frame makes it look WebKit-related. A full backtrace against an unstripped build shows the real cause:

```
GUI_App::OnExit()
  -> std::exit(0)
    -> <C++ global/static destructors>
      -> Slic3r::GUI::GLModel::~GLModel()
        -> GLModel::reset()
          -> GLModel::RenderData::release()
            -> ::glDeleteBuffers()          <-- SIGSEGV
```

`GUI_App::OnExit()` ends with `std::exit(0)`, which drives the C++ global/static destructors. Static `GLModel` instances are torn down there and call `RenderData::release() -> glDeleteBuffers()` **after the GL/GTK context has already been destroyed**, so the GL entry point is stale and dereferencing it faults. breakpad's signal handler then double-faults on top (see second commit).

## Fix

**1. Skip the global-destructor teardown on Linux exit.** All persistent state (AppConfig, presets) is already saved during the window-close sequence and `wxApp::OnExit()`, so there is nothing left to flush by the time we reach the end of `OnExit()`. On Linux, terminate via `std::_Exit(0)` instead of `std::exit(0)` to avoid running the global destructors that touch a dead GL context. Windows/macOS are unchanged (`#ifdef __linux__`).

**2. Make `dumpCallback` exception-safe.** It runs from breakpad's signal handler but performs throwing `boost::filesystem` operations (`rename`, `create_directories`). When one throws (e.g. the crash-dump dir is missing) the exception unwinds out of the signal handler and double-faults into a second, harder crash, losing the minidump. The body is now wrapped in a catch-all so no exception can escape the handler.

## Testing

Built for Linux (Ubuntu 24.04 / GCC 13) and run on Arch Linux + X11. Before: a `SIGSEGV` coredump on every exit. After: the app exits cleanly, no coredump.

Both changes are Linux-only in effect and don't alter Windows/macOS behavior.
