### PR TITLE
disable_arc_fitting on K1 machines

### DIFF
--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1 Max 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.08mm Standard @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm Standard @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1 Max 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1 SE 0.4 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.16mm Standard @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Standard @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm  Standard @Creality K1 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm  Standard @Creality K1 SE 0.4 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1 Max 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1 Max 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1 Max_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1 SE 0.4 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1 SE_CFS-C 0.4 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1C 2025_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1C_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.24mm Standard @Creality K1_CFS-C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Standard @Creality K1_CFS-C 0.4 nozzle.json
@@ -39,7 +39,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 0.6 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 Max 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 Max 0.6 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 SE 0.6 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1 0.8 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1 Max 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1 Max 0.8 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1 SE 0.8 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
@@ -38,7 +38,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
     "elefant_foot_compensation_layers": "1",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "enable_overhang_speed": "1",
     "enable_prime_tower": "0",
     "enable_support": "0",


### PR DESCRIPTION
# Description

The K1 Series, whether it's K1, K1C, K1 Max, or whatever K1 models are out there, have a very weak MCU that often triggers MQO or TTC errors related to long or complex move queues, which literally shut down the MCU or even crash it with no proper HW debug options, due to the K1 potato board not having a JTAG port. Gigatons of Filament were wasted worldwide.

All the K1* process profiles have "enable_arc_fitting" enabled by default. This setting very often is disabled by users., as there is no real benefit in Klipper versus Marlin.
By disabling them by default, we get more reliable prints, especially if the gcode is very complex, thus saving MCU resources.
