### PR TITLE
Support Linux Mint in BuildLinux.sh (map to Ubuntu base)

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -115,6 +115,19 @@ then
         DISTRIBUTION="debian2"
     fi
 fi
+# Treat Linux Mint like its Ubuntu base (Mint 22.x is based on Ubuntu 24.04)
+if [ "${DISTRIBUTION}" == "linuxmint" ]
+then
+    DISTRIBUTION="debian"
+    VERSION_ID=$(awk -F= '/^VERSION_ID=/ {print $2}' /etc/os-release)
+    NUMERIC_VERSION=$(echo ${VERSION_ID} | tr -d '"')
+    MINT_MAJOR=${NUMERIC_VERSION%%.*}
+    # Mint 22.x => Ubuntu 24.04 => debian2
+    if [ "${MINT_MAJOR}" -ge 22 ]
+    then
+        DISTRIBUTION="debian2"
+    fi
+fi
 # 兼容麒麟系统（Kylin/openKylin），使用专用脚本
 if [ "${DISTRIBUTION}" == "kylin" ] || [ "${DISTRIBUTION}" == "openkylin" ]
 then


### PR DESCRIPTION
## Summary

`BuildLinux.sh` aborts on Linux Mint with *"Your distribution does not appear to
be currently supported by these build scripts"*, so Mint users can't build.

## Cause

Distro detection reads `ID=` from `/etc/os-release` and maps `ubuntu` to the
`debian` / `debian2` profiles, but Linux Mint reports `ID=linuxmint`, for which
there is no `linux.d/` profile — so the script exits early before configuring.

## Fix

Treat Linux Mint like its Ubuntu base, mirroring the existing `ubuntu` handling:

- Mint 22.x (Ubuntu 24.04 base) → `debian2`
- older Mint → `debian`

Uses an integer major-version comparison (`${VERSION_ID%%.*}`) so detection does
not depend on `bc` being installed.

## Testing

Built on Linux Mint 22.3 (Ubuntu 24.04 base, GCC 13): `sudo ./BuildLinux.sh -u`
now resolves to the `debian2` profile and installs the dependencies, and a full
`-d` / `-s` / `-i` build completes.

## Notes

Linux-only; no effect on detection for other distributions. Reuses the
`debian2` profile and mirrors the `ubuntu` → `debian2` logic already present in
the script.
